### PR TITLE
Add a linter to stop the 'any' type being used

### DIFF
--- a/packages/eslint-plugin-internal/rule-overrides/typescript-overrides.js
+++ b/packages/eslint-plugin-internal/rule-overrides/typescript-overrides.js
@@ -6,4 +6,7 @@ module.exports = {
   // Disallow variable declarations from shadowing variables declared in the outer scope
   'no-shadow': 'off',
   '@typescript-eslint/no-shadow': 'error',
+
+  // We intentionally do not want type ambiguity in the SDK
+  '@typescript-eslint/no-explicit-any': 'error',
 };


### PR DESCRIPTION
/cc @vojtechszocs 

Adding no explicit `any` now so we don't have any slip up from our definitions as we grow. We are an SDK, not an App... luxury on types should not be granted to us.