### PR TITLE
Add PluginStoreContext

### DIFF
--- a/packages/eslint-plugin-internal/configs/typescript.js
+++ b/packages/eslint-plugin-internal/configs/typescript.js
@@ -18,7 +18,6 @@ module.exports = {
 
       plugins: ['@typescript-eslint'],
 
-      // Override existing rules with TypeScript equivalents
       rules: require('../rule-overrides/typescript-overrides'),
     },
   ],

--- a/packages/eslint-plugin-internal/rule-overrides/react-typescript-prettier.js
+++ b/packages/eslint-plugin-internal/rule-overrides/react-typescript-prettier.js
@@ -1,4 +1,13 @@
 module.exports = {
   // Ensure consistent use of file extension within the import path
   'import/extensions': 'off',
+
+  // Enforce a specific function type for function components
+  'react/function-component-definition': [
+    'error',
+    {
+      namedComponents: 'arrow-function',
+      unnamedComponents: 'arrow-function',
+    },
+  ],
 };

--- a/packages/eslint-plugin-internal/rule-overrides/typescript-overrides.js
+++ b/packages/eslint-plugin-internal/rule-overrides/typescript-overrides.js
@@ -6,4 +6,13 @@ module.exports = {
   // Disallow variable declarations from shadowing variables declared in the outer scope
   'no-shadow': 'off',
   '@typescript-eslint/no-shadow': 'error',
+
+  // Restrict file extensions that may contain JSX
+  'react/jsx-filename-extension': [
+    'error',
+    {
+      allow: 'as-needed',
+      extensions: ['.tsx'],
+    },
+  ],
 };

--- a/packages/lib-runtime/package.json
+++ b/packages/lib-runtime/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@types/lodash-es": "^4.17.5",
     "@types/node": "^12.20.36",
+    "@types/react": "^17.0.37",
     "eslint-plugin-internal": "0.0.0-fixed",
     "typescript": "^4.4.4"
   }

--- a/packages/lib-runtime/src/index.ts
+++ b/packages/lib-runtime/src/index.ts
@@ -1,2 +1,3 @@
 export * from './store/PluginLoader';
 export * from './store/PluginStore';
+export * from './store/PluginStoreContext';

--- a/packages/lib-runtime/src/store/PluginStore.ts
+++ b/packages/lib-runtime/src/store/PluginStore.ts
@@ -7,10 +7,10 @@ import { PluginLoader } from './PluginLoader';
 /**
  * Client interface for `PluginStore` consumers.
  */
-export interface PluginStoreClient<TLoadedExtension extends LoadedExtension> {
+export interface PluginStoreClient<TLoadedExtension extends LoadedExtension = LoadedExtension> {
   subscribe: (listener: VoidFunction, eventTypes: PluginStoreEventType[]) => VoidFunction;
   getExtensions: () => TLoadedExtension[];
-  getPluginInfo: () => (LoadedPluginInfo | NotLoadedPluginInfo)[];
+  getPluginInfo: () => PluginInfo[];
 }
 
 type LoadedPluginInfo = {
@@ -24,6 +24,8 @@ type NotLoadedPluginInfo = {
   pluginName: string;
   status: 'pending' | 'failed';
 };
+
+export type PluginInfo = LoadedPluginInfo | NotLoadedPluginInfo;
 
 export enum PluginStoreEventType {
   /** Plugin was successfully loaded, processed and added to the `PluginStore`. */
@@ -46,7 +48,7 @@ export type PluginStoreOptions = Partial<{
 /**
  * Provides access to runtime plugin information and extensions.
  */
-export class PluginStore<TLoadedExtension extends LoadedExtension>
+export class PluginStore<TLoadedExtension extends LoadedExtension = LoadedExtension>
   implements PluginStoreClient<TLoadedExtension>
 {
   private readonly options: Required<PluginStoreOptions>;
@@ -110,6 +112,10 @@ export class PluginStore<TLoadedExtension extends LoadedExtension>
       unsubscribe();
       this.loader = undefined;
     };
+  }
+
+  hasLoader() {
+    return this.loader !== undefined;
   }
 
   /**

--- a/packages/lib-runtime/src/store/PluginStoreContext.tsx
+++ b/packages/lib-runtime/src/store/PluginStoreContext.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { PluginStore, PluginStoreClient } from './PluginStore';
+
+const PluginStoreContext = React.createContext<PluginStore | undefined>(undefined);
+
+/**
+ * React Context provider for passing the `PluginStore` down the component tree.
+ */
+export const PluginStoreProvider: React.FC<PluginStoreProviderProps> = ({ store, children }) => {
+  if (!store.hasLoader()) {
+    throw new Error('PluginLoader must be set on the PluginStore');
+  }
+
+  return <PluginStoreContext.Provider value={store}>{children}</PluginStoreContext.Provider>;
+};
+
+type PluginStoreProviderProps = React.PropsWithChildren<{
+  store: PluginStore;
+}>;
+
+/**
+ * React hook for consuming the `PluginStore` via its client interface.
+ */
+export const usePluginStore = (): PluginStoreClient => {
+  const store = React.useContext(PluginStoreContext);
+
+  if (store === undefined) {
+    throw new Error('usePluginStore hook called outside a PluginStoreProvider');
+  }
+
+  return store;
+};

--- a/tsconfig-bases/all-targets.json
+++ b/tsconfig-bases/all-targets.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "noEmitOnError": true,
     "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/tsconfig-bases/react-esm.json
+++ b/tsconfig-bases/react-esm.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "target": "es2021",
     "module": "esnext",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "jsx": "react"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,6 +135,7 @@ __metadata:
   dependencies:
     "@types/lodash-es": ^4.17.5
     "@types/node": ^12.20.36
+    "@types/react": ^17.0.37
     eslint-plugin-internal: 0.0.0-fixed
     joi: ^17.4.2
     lodash-es: ^4.17.21
@@ -200,6 +201,31 @@ __metadata:
   version: 12.20.37
   resolution: "@types/node@npm:12.20.37"
   checksum: 8c8b12f802678b3b87c5344b6c84082be08561dda81dc161d42be8cd327330d1a5227cef039c45a5e63a6d4a01ef5ef215dccc42d06100f59f6a8814b4f91cdd
+  languageName: node
+  linkType: hard
+
+"@types/prop-types@npm:*":
+  version: 15.7.4
+  resolution: "@types/prop-types@npm:15.7.4"
+  checksum: ef6e1899e59b876c273811b1bd845022fc66d5a3d11cb38a25b6c566b30514ae38fe20a40f67622f362a4f4f7f9224e22d8da101cff3d6e97e11d7b4c307cfc1
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^17.0.37":
+  version: 17.0.37
+  resolution: "@types/react@npm:17.0.37"
+  dependencies:
+    "@types/prop-types": "*"
+    "@types/scheduler": "*"
+    csstype: ^3.0.2
+  checksum: e68b0d59aa69577fc6a6d654b25d5d8408625498f4c483f160b557fac21e840f6e8807cbde93e9f039949b6d624a019b1990d18499c1d65aecf3605c25e30242
+  languageName: node
+  linkType: hard
+
+"@types/scheduler@npm:*":
+  version: 0.16.2
+  resolution: "@types/scheduler@npm:0.16.2"
+  checksum: b6b4dcfeae6deba2e06a70941860fb1435730576d3689225a421280b7742318d1548b3d22c1f66ab68e414f346a9542f29240bc955b6332c5b11e561077583bc
   languageName: node
   linkType: hard
 
@@ -591,6 +617,13 @@ __metadata:
     shebang-command: ^2.0.0
     which: ^2.0.1
   checksum: 671cc7c7288c3a8406f3c69a3ae2fc85555c04169e9d611def9a675635472614f1c0ed0ef80955d5b6d4e724f6ced67f0ad1bb006c2ea643488fcfef994d7f52
+  languageName: node
+  linkType: hard
+
+"csstype@npm:^3.0.2":
+  version: 3.0.10
+  resolution: "csstype@npm:3.0.10"
+  checksum: 20a8fa324f2b33ddf94aa7507d1b6ab3daa6f3cc308888dc50126585d7952f2471de69b2dbe0635d1fdc31223fef8e070842691877e725caf456e2378685a631
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Code in `PluginStoreContext.tsx` is inspired by article [How to use React Context effectively](https://kentcdodds.com/blog/how-to-use-react-context-effectively).

> Note that I'm _NOT_ exporting `CountContext`. This is intentional. I expose only one way to provide the context value and only one way to consume it. This allows me to ensure that people are using the context value the way it should be and it allows me to provide useful utilities for my consumers.

`react-esm.json` TypeScript config base adapted to support JSX syntax (applies to `.tsx` files).

Note that by default, TypeScript does _not_ allow plain JavaScript code to be imported ([`allowJs`](https://www.typescriptlang.org/tsconfig#allowJs) defaults to `false`).