### PR TITLE
Add logic to process code references

### DIFF
--- a/packages/common/src/errors/CustomError.ts
+++ b/packages/common/src/errors/CustomError.ts
@@ -10,8 +10,8 @@ export class CustomError extends Error {
     // Set name as constructor name, while keeping its property descriptor compatible with Error.name
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_constructors
     Object.defineProperty(this, 'name', {
-      ...Object.getOwnPropertyDescriptor(this, 'name'),
       value: new.target.name,
+      configurable: true,
     });
 
     // Populate stack property via Error.captureStackTrace (when available) or manually via new Error()

--- a/packages/common/src/types/common.ts
+++ b/packages/common/src/types/common.ts
@@ -16,3 +16,10 @@ export type AnyObject = Record<string, unknown>;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyFunction = (...args: any) => any;
+
+/**
+ * Replace existing direct properties of object `T` with ones declared in object `R`.
+ */
+export type ReplaceProperties<T extends AnyObject, R extends AnyObject> = {
+  [K in keyof T]: K extends keyof R ? R[K] : T[K];
+} & AnyObject;

--- a/packages/common/src/utils/objects.ts
+++ b/packages/common/src/utils/objects.ts
@@ -18,19 +18,13 @@ export const applyOverrides = <TObject>(obj: TObject, overrides: TObject): TObje
   _.defaultsDeep({}, overrides, obj);
 
 /**
- * Return `true` if `obj` is a plain non-React object.
- */
-export const isPlainNonReactObject = (obj: unknown): obj is AnyObject =>
-  _.isPlainObject(obj) && !(obj as AnyObject).$$typeof;
-
-/**
  * Recursive equivalent of {@link _.forOwn} function that traverses plain objects and arrays.
  */
 export const visitDeep = <TValue>(
   obj: AnyObject,
   predicate: (value: unknown) => value is TValue,
   valueCallback: (value: TValue, key: string, container: AnyObject) => void,
-  isPlainObject = isPlainNonReactObject,
+  isPlainObject: (obj: unknown) => obj is AnyObject = (o): o is AnyObject => _.isPlainObject(o),
 ) => {
   const visitValue = (value: unknown, key: string, container: AnyObject) => {
     if (predicate(value)) {

--- a/packages/common/src/utils/objects.ts
+++ b/packages/common/src/utils/objects.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash-es';
+import type { AnyObject } from '../types/common';
 
 /**
  * Create new object by recursively assigning property defaults to `obj`.
@@ -15,3 +16,33 @@ export const applyDefaults = <TObject>(obj: TObject, defaults: TObject): TObject
  */
 export const applyOverrides = <TObject>(obj: TObject, overrides: TObject): TObject =>
   _.defaultsDeep({}, overrides, obj);
+
+/**
+ * Return `true` if `obj` is a plain non-React object.
+ */
+export const isPlainNonReactObject = (obj: unknown): obj is AnyObject =>
+  _.isPlainObject(obj) && !(obj as AnyObject).$$typeof;
+
+/**
+ * Recursive equivalent of {@link _.forOwn} function that traverses plain objects and arrays.
+ */
+export const visitDeep = <TValue>(
+  obj: AnyObject,
+  predicate: (value: unknown) => value is TValue,
+  valueCallback: (value: TValue, key: string, container: AnyObject) => void,
+  isPlainObject = isPlainNonReactObject,
+) => {
+  const visitValue = (value: unknown, key: string, container: AnyObject) => {
+    if (predicate(value)) {
+      valueCallback(value, key, container);
+    } else if (isPlainObject(value)) {
+      visitDeep(value, predicate, valueCallback, isPlainObject);
+    } else if (Array.isArray(value)) {
+      value.forEach((element) => {
+        visitDeep(element, predicate, valueCallback, isPlainObject);
+      });
+    }
+  };
+
+  _.forOwn(obj, visitValue);
+};

--- a/packages/lib-runtime/src/schema/plugin-manifest.ts
+++ b/packages/lib-runtime/src/schema/plugin-manifest.ts
@@ -44,22 +44,21 @@ const extensionType = yup
 /**
  * Schema for `Extension` objects.
  */
-const extension = yup
-  .object({
-    type: extensionType,
-    properties: yup.object().required(),
-  })
-  .required();
+const extension = yup.object().required().shape({
+  type: extensionType,
+  properties: yup.object().required(),
+});
 
 /**
  * Schema for `PluginManifest` objects.
  */
 export const pluginManifest = yup
-  .object({
+  .object()
+  .required()
+  .shape({
     name: pluginName,
     version: semverString,
     extensions: yup.array().of(extension).required(),
-  })
-  .required();
+  });
 
 export { pluginManifest as pluginManifestSchema };

--- a/packages/lib-runtime/src/store/PluginLoader.ts
+++ b/packages/lib-runtime/src/store/PluginLoader.ts
@@ -2,7 +2,7 @@ import type { AnyObject, ResourceFetch } from '@monorepo/common';
 import * as _ from 'lodash-es';
 import { pluginManifestSchema } from '../schema/plugin-manifest';
 import type { PluginManifest } from '../types/plugin';
-import type { PluginEntryCallback } from '../types/runtime';
+import type { PluginEntryModule, PluginEntryCallback } from '../types/runtime';
 import { basicFetch } from '../utils/basic-fetch';
 import { consoleLogger } from '../utils/logger';
 import { resolveURL } from '../utils/url';
@@ -17,6 +17,7 @@ type PluginLoadResult =
   | {
       success: true;
       manifest: PluginManifest;
+      entryModule: PluginEntryModule;
     }
   | {
       success: false;
@@ -188,7 +189,7 @@ export class PluginLoader {
         .then(() => {
           data.status = 'loaded';
           consoleLogger.info(`Entry script for plugin ${pluginName} loaded successfully`);
-          this.invokeListeners(pluginName, { success: true, manifest: data.manifest });
+          this.invokeListeners(pluginName, { success: true, manifest: data.manifest, entryModule });
         })
         .catch((e) => {
           data.status = 'failed';

--- a/packages/lib-runtime/src/store/coderefs.ts
+++ b/packages/lib-runtime/src/store/coderefs.ts
@@ -1,7 +1,13 @@
 import type { AnyObject } from '@monorepo/common';
 import { CustomError, visitDeep } from '@monorepo/common';
 import * as _ from 'lodash-es';
-import type { EncodedCodeRef, CodeRef, LoadedExtension } from '../types/extension';
+import type {
+  EncodedCodeRef,
+  CodeRef,
+  Extension,
+  LoadedExtension,
+  ResolvedExtension,
+} from '../types/extension';
 import type { PluginEntryModule } from '../types/runtime';
 
 class CodeRefError extends CustomError {
@@ -10,24 +16,20 @@ class CodeRefError extends CustomError {
   }
 }
 
+/**
+ * Indicates that the given function is a {@link CodeRef} function.
+ */
 const codeRefSymbol = Symbol('CodeRef');
 
-/**
- * Check if the given object has the {@link EncodedCodeRef} shape.
- */
 const isEncodedCodeRef = (obj: unknown): obj is EncodedCodeRef =>
   _.isPlainObject(obj) &&
   _.isEqual(Object.getOwnPropertyNames(obj), ['$codeRef']) &&
   typeof (obj as EncodedCodeRef).$codeRef === 'string';
 
-/**
- * Check if the given object is a {@link CodeRef} function.
- */
 const isCodeRef = (obj: unknown): obj is CodeRef =>
   typeof obj === 'function' &&
   _.isEqual(Object.getOwnPropertySymbols(obj), [codeRefSymbol]) &&
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (obj as any)[codeRefSymbol] === true;
+  (obj as unknown as Record<symbol, unknown>)[codeRefSymbol] === true;
 
 /**
  * Parse data from the {@link EncodedCodeRef} object.
@@ -37,7 +39,7 @@ const isCodeRef = (obj: unknown): obj is CodeRef =>
 const parseEncodedCodeRef = (
   ref: EncodedCodeRef,
 ): [moduleName: string, exportName: string] | undefined => {
-  const match = ref.$codeRef.match(/^([^.]+)(?:\.([^.]+)){0,1}$/);
+  const match = ref.$codeRef.match(/^([^.\s]+)(?:\.([^.\s]+))?$/);
 
   if (!match) {
     return undefined;
@@ -46,45 +48,29 @@ const parseEncodedCodeRef = (
   const moduleName = match[1];
   const exportName = match[2] || 'default';
 
-  if (!moduleName || !exportName) {
-    return undefined;
-  }
-
-  if (moduleName !== moduleName.trim() || exportName !== exportName.trim()) {
-    return undefined;
-  }
-
   return [moduleName, exportName];
 };
 
 /**
- * Create a {@link CodeRef} function from the {@link EncodedCodeRef} object.
- *
- * The referenced object is resolved just once. Multiple {@link CodeRef} Promise resolutions
- * yield the exact same value.
+ * Create new {@link CodeRef} function from an {@link EncodedCodeRef} object.
  */
-const createCodeRef = (
-  encodedRef: EncodedCodeRef,
-  entryModule: PluginEntryModule,
-  formatErrorMessage: (message: string) => string = _.identity,
-): CodeRef => {
-  let referencedObject: unknown;
-  let referencedObjectResolved = false;
-
-  const codeRef: CodeRef = async () => {
-    if (referencedObjectResolved) {
-      return referencedObject;
-    }
-
-    const refData = parseEncodedCodeRef(encodedRef);
+const createCodeRef =
+  (
+    encodedCodeRef: EncodedCodeRef,
+    entryModule: PluginEntryModule,
+    formatErrorMessage: (message: string) => string = _.identity,
+  ): CodeRef =>
+  async () => {
+    const refData = parseEncodedCodeRef(encodedCodeRef);
 
     if (!refData) {
       throw new CodeRefError(
-        formatErrorMessage(`Malformed code reference '${encodedRef.$codeRef}'`),
+        formatErrorMessage(`Malformed code reference '${encodedCodeRef.$codeRef}'`),
       );
     }
 
     const [moduleName, exportName] = refData;
+
     let referencedModule: AnyObject;
 
     try {
@@ -100,51 +86,87 @@ const createCodeRef = (
       );
     }
 
-    referencedObject = referencedModule[exportName];
-    referencedObjectResolved = true;
-
-    return referencedObject;
+    return referencedModule[exportName];
   };
-
-  // Mark the function with a non-configurable symbol property
-  Object.defineProperty(codeRef, codeRefSymbol, { value: true });
-
-  return codeRef;
-};
 
 /**
  * In the extension's `properties` object, replace all {@link EncodedCodeRef} values
  * with {@link CodeRef} functions that can be used to load the referenced objects.
+ *
+ * Returns the updated extension instance.
  */
-export const decodeExtensionCodeRefs = (
+export const decodeCodeRefs = (
   extension: LoadedExtension,
   entryModule: PluginEntryModule,
+  codeRefCache: Map<string, CodeRef>,
 ) => {
-  visitDeep<EncodedCodeRef>(extension.properties, isEncodedCodeRef, (encodedRef, key, obj) => {
-    const codeRef = createCodeRef(
-      encodedRef,
-      entryModule,
-      (message) => `${message} in extension ${extension.uid}`,
-    );
+  visitDeep<EncodedCodeRef>(extension.properties, isEncodedCodeRef, (encodedCodeRef, key, obj) => {
+    const codeRefKey = `${extension.pluginName}[${encodedCodeRef.$codeRef}]`;
 
-    // Use a sensible function name that reflects the contextual information
-    Object.defineProperty(codeRef, 'name', {
-      value: `$codeRef_${extension.uid}_${encodedRef}`,
-      configurable: true,
-    });
+    let codeRef: CodeRef;
+
+    if (codeRefCache.has(codeRefKey)) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      codeRef = codeRefCache.get(codeRefKey)!;
+    } else {
+      codeRef = createCodeRef(
+        encodedCodeRef,
+        entryModule,
+        (message) => `${message} in extension ${extension.uid}`,
+      );
+
+      // Use a sensible function name that reflects the current context
+      Object.defineProperty(codeRef, 'name', {
+        value: `$codeRef_${codeRefKey}`,
+        configurable: true,
+      });
+
+      // Mark the function with a non-configurable symbol property
+      Object.defineProperty(codeRef, codeRefSymbol, { value: true });
+
+      codeRefCache.set(codeRefKey, codeRef);
+    }
 
     // eslint-disable-next-line no-param-reassign
     obj[key] = codeRef;
   });
+
+  return extension;
 };
 
 /**
  * In the extension's `properties` object, replace all {@link CodeRef} functions
- * with the corresponding values resolved by executing these functions.
+ * with the corresponding values by resolving the associated Promises.
+ *
+ * This is an asynchronous operation that completes when all of the associated
+ * Promises are either resolved or rejected. If there were no resolution errors,
+ * the resulting Promise resolves to the updated extension instance.
  */
-export const resolveExtensionCodeRefValues = (extension: LoadedExtension) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const resolveCodeRefValues = async <TExtension extends Extension>(extension: TExtension) => {
+  const resolutions: Promise<void>[] = [];
+  const resolutionErrors: unknown[] = [];
+
   visitDeep<CodeRef>(extension.properties, isCodeRef, (codeRef, key, obj) => {
-    // TODO not implemented yet
+    resolutions.push(
+      codeRef()
+        // eslint-disable-next-line promise/always-return -- resolutions element type is Promise<void>
+        .then((resolvedValue) => {
+          // eslint-disable-next-line no-param-reassign
+          obj[key] = resolvedValue;
+        })
+        .catch((e) => {
+          resolutionErrors.push(e);
+          // eslint-disable-next-line no-param-reassign
+          obj[key] = undefined;
+        }),
+    );
   });
+
+  await Promise.allSettled(resolutions);
+
+  if (resolutionErrors.length > 0) {
+    throw new CodeRefError('Failed to resolve code references', resolutionErrors);
+  }
+
+  return extension as ResolvedExtension<TExtension>;
 };

--- a/packages/lib-runtime/src/store/coderefs.ts
+++ b/packages/lib-runtime/src/store/coderefs.ts
@@ -1,0 +1,150 @@
+import type { AnyObject } from '@monorepo/common';
+import { CustomError, visitDeep } from '@monorepo/common';
+import * as _ from 'lodash-es';
+import type { EncodedCodeRef, CodeRef, LoadedExtension } from '../types/extension';
+import type { PluginEntryModule } from '../types/runtime';
+
+class CodeRefError extends CustomError {
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+  }
+}
+
+const codeRefSymbol = Symbol('CodeRef');
+
+/**
+ * Check if the given object has the {@link EncodedCodeRef} shape.
+ */
+const isEncodedCodeRef = (obj: unknown): obj is EncodedCodeRef =>
+  _.isPlainObject(obj) &&
+  _.isEqual(Object.getOwnPropertyNames(obj), ['$codeRef']) &&
+  typeof (obj as EncodedCodeRef).$codeRef === 'string';
+
+/**
+ * Check if the given object is a {@link CodeRef} function.
+ */
+const isCodeRef = (obj: unknown): obj is CodeRef =>
+  typeof obj === 'function' &&
+  _.isEqual(Object.getOwnPropertySymbols(obj), [codeRefSymbol]) &&
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (obj as any)[codeRefSymbol] === true;
+
+/**
+ * Parse data from the {@link EncodedCodeRef} object.
+ *
+ * Returns `undefined` if the `$codeRef` value is malformed.
+ */
+const parseEncodedCodeRef = (
+  ref: EncodedCodeRef,
+): [moduleName: string, exportName: string] | undefined => {
+  const match = ref.$codeRef.match(/^([^.]+)(?:\.([^.]+)){0,1}$/);
+
+  if (!match) {
+    return undefined;
+  }
+
+  const moduleName = match[1];
+  const exportName = match[2] || 'default';
+
+  if (!moduleName || !exportName) {
+    return undefined;
+  }
+
+  if (moduleName !== moduleName.trim() || exportName !== exportName.trim()) {
+    return undefined;
+  }
+
+  return [moduleName, exportName];
+};
+
+/**
+ * Create a {@link CodeRef} function from the {@link EncodedCodeRef} object.
+ *
+ * The referenced object is resolved just once. Multiple {@link CodeRef} Promise resolutions
+ * yield the exact same value.
+ */
+const createCodeRef = (
+  encodedRef: EncodedCodeRef,
+  entryModule: PluginEntryModule,
+  formatErrorMessage: (message: string) => string = _.identity,
+): CodeRef => {
+  let referencedObject: unknown;
+  let referencedObjectResolved = false;
+
+  const codeRef: CodeRef = async () => {
+    if (referencedObjectResolved) {
+      return referencedObject;
+    }
+
+    const refData = parseEncodedCodeRef(encodedRef);
+
+    if (!refData) {
+      throw new CodeRefError(
+        formatErrorMessage(`Malformed code reference '${encodedRef.$codeRef}'`),
+      );
+    }
+
+    const [moduleName, exportName] = refData;
+    let referencedModule: AnyObject;
+
+    try {
+      const moduleFactory = await entryModule.get(moduleName);
+      referencedModule = moduleFactory();
+    } catch (e) {
+      throw new CodeRefError(formatErrorMessage(`Failed to load module '${moduleName}'`), e);
+    }
+
+    if (!_.has(referencedModule, exportName)) {
+      throw new CodeRefError(
+        formatErrorMessage(`Missing module export '${moduleName}.${exportName}'`),
+      );
+    }
+
+    referencedObject = referencedModule[exportName];
+    referencedObjectResolved = true;
+
+    return referencedObject;
+  };
+
+  // Mark the function with a non-configurable symbol property
+  Object.defineProperty(codeRef, codeRefSymbol, { value: true });
+
+  return codeRef;
+};
+
+/**
+ * In the extension's `properties` object, replace all {@link EncodedCodeRef} values
+ * with {@link CodeRef} functions that can be used to load the referenced objects.
+ */
+export const decodeExtensionCodeRefs = (
+  extension: LoadedExtension,
+  entryModule: PluginEntryModule,
+) => {
+  visitDeep<EncodedCodeRef>(extension.properties, isEncodedCodeRef, (encodedRef, key, obj) => {
+    const codeRef = createCodeRef(
+      encodedRef,
+      entryModule,
+      (message) => `${message} in extension ${extension.uid}`,
+    );
+
+    // Use a sensible function name that reflects the contextual information
+    Object.defineProperty(codeRef, 'name', {
+      value: `$codeRef_${extension.uid}_${encodedRef}`,
+      configurable: true,
+    });
+
+    // eslint-disable-next-line no-param-reassign
+    obj[key] = codeRef;
+  });
+};
+
+/**
+ * In the extension's `properties` object, replace all {@link CodeRef} functions
+ * with the corresponding values resolved by executing these functions.
+ */
+export const resolveExtensionCodeRefValues = (extension: LoadedExtension) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  visitDeep<CodeRef>(extension.properties, isCodeRef, (codeRef, key, obj) => {
+    // TODO not implemented yet
+  });
+};

--- a/packages/lib-runtime/src/types/extension.ts
+++ b/packages/lib-runtime/src/types/extension.ts
@@ -1,8 +1,4 @@
-import type { AnyObject } from '@monorepo/common';
-
-export type EncodedCodeRef = { $codeRef: string };
-
-export type CodeRef<T = unknown> = () => Promise<T>;
+import type { AnyObject, ReplaceProperties } from '@monorepo/common';
 
 export type Extension<TType extends string = string, TProperties extends AnyObject = AnyObject> = {
   type: TType;
@@ -17,3 +13,27 @@ export type LoadedExtension<TExtension extends Extension = Extension> = TExtensi
 };
 
 export type ExtensionPredicate<TExtension extends Extension> = (e: Extension) => e is TExtension;
+
+export type EncodedCodeRef = { $codeRef: string };
+
+export type CodeRef<TValue = unknown> = () => Promise<TValue>;
+
+// TODO(vojtech) apply the recursive part only on object properties or array elements
+type ExtractCodeRefValues<T> = {
+  [K in keyof T]: T[K] extends CodeRef<infer TValue> ? TValue : ExtractCodeRefValues<T[K]>;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ExtractExtensionProperties<T> = T extends Extension<any, infer TProperties>
+  ? TProperties
+  : never;
+
+export type ResolvedExtension<TExtension extends Extension> = ReplaceProperties<
+  TExtension,
+  {
+    properties: ReplaceProperties<
+      ExtractExtensionProperties<TExtension>,
+      ExtractCodeRefValues<ExtractExtensionProperties<TExtension>>
+    >;
+  }
+>;

--- a/packages/lib-runtime/src/types/extension.ts
+++ b/packages/lib-runtime/src/types/extension.ts
@@ -1,7 +1,11 @@
 import type { AnyObject } from '@monorepo/common';
 
-export type Extension<TProperties extends AnyObject = AnyObject> = {
-  type: string;
+export type EncodedCodeRef = { $codeRef: string };
+
+export type CodeRef<T = unknown> = () => Promise<T>;
+
+export type Extension<TType extends string = string, TProperties extends AnyObject = AnyObject> = {
+  type: TType;
   properties: TProperties;
   [customProperty: string]: unknown;
 };

--- a/packages/lib-runtime/src/utils/objects.ts
+++ b/packages/lib-runtime/src/utils/objects.ts
@@ -17,7 +17,9 @@ export const createMethodDelegate = <
 ) => {
   const delegate = {} as Pick<TObject, TObjectMethods>;
 
-  const validMethodNames = methodNames.filter((methodName) => _.isFunction(target[methodName]));
+  const validMethodNames = methodNames.filter(
+    (methodName) => typeof target[methodName] === 'function',
+  );
 
   if (!_.isEqual(methodNames, validMethodNames)) {
     throw new Error(


### PR DESCRIPTION
Fixes [HAC-444](https://issues.redhat.com/browse/HAC-444)

- add `EncodedCodeRef` and `CodeRef` types
- add `ResolvedExtension` type, to be used with upcoming `useResolvedExtensions` hook
- modify `Extension` type to allow subtyping its `type` property, for example:
```ts
export type Foo = Extension<
  'core.foo',
  {
    bar: string;
    qux: CodeRef<VoidFunction>;
  }
>;
```
- `decodeCodeRefs` function implements `EncodedCodeRef` :arrow_right: `CodeRef` value transformation (sync)
- `resolveCodeRefValues` function implements `CodeRef<T>` :arrow_right: `T` value transformation (async)
- `PluginStore` now uses `Map<string, CodeRef>` to preserve referential identity of `CodeRef` functions
- `CodeRef` cache key is composed of `pluginName` (e.g. `kubevirt`) and the encoded `$codeRef` value (e.g. `icons.vmIconElement`) so basically a composite key `<pluginName,(exposed)moduleName,exportName>`