### PR TITLE
Add useResolvedExtensions hook

### DIFF
--- a/packages/lib-runtime/src/index.ts
+++ b/packages/lib-runtime/src/index.ts
@@ -7,3 +7,4 @@ export {
 } from './store/PluginStoreContext';
 export { useExtensions } from './store/useExtensions';
 export { usePluginInfo } from './store/usePluginInfo';
+export { useResolvedExtensions } from './store/useResolvedExtensions';

--- a/packages/lib-runtime/src/store/PluginStoreContext.tsx
+++ b/packages/lib-runtime/src/store/PluginStoreContext.tsx
@@ -47,7 +47,7 @@ export const usePluginManager = (): PluginManager => {
   }
 
   return React.useMemo(
-    () => createMethodDelegate(store, ['loadPlugin', 'setPluginEnabled']),
+    () => createMethodDelegate(store, ['loadPlugin', 'setPluginsEnabled']),
     [store],
   );
 };

--- a/packages/lib-runtime/src/store/useExtensions.ts
+++ b/packages/lib-runtime/src/store/useExtensions.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash-es';
 import * as React from 'react';
 import type { Extension, LoadedExtension, ExtensionPredicate } from '../types/extension';
 import type { PluginConsumer } from '../types/store';
@@ -7,6 +8,9 @@ import { usePluginSubscription } from './usePluginSubscription';
 const eventTypes = [PluginEventType.ExtensionsChanged];
 
 const getData = (pluginConsumer: PluginConsumer) => pluginConsumer.getExtensions();
+
+const isSameData = (prevData: LoadedExtension[], nextData: LoadedExtension[]) =>
+  _.isEqualWith(prevData, nextData, (a, b) => a === b);
 
 /**
  * React hook for consuming extensions which are currently in use.
@@ -20,7 +24,7 @@ const getData = (pluginConsumer: PluginConsumer) => pluginConsumer.getExtensions
 export const useExtensions = <TExtension extends Extension>(
   predicate?: ExtensionPredicate<TExtension>,
 ): LoadedExtension<TExtension>[] => {
-  const extensions = usePluginSubscription(eventTypes, getData);
+  const extensions = usePluginSubscription(eventTypes, getData, isSameData);
 
   return React.useMemo(
     () =>

--- a/packages/lib-runtime/src/store/useResolvedExtensions.ts
+++ b/packages/lib-runtime/src/store/useResolvedExtensions.ts
@@ -1,0 +1,80 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import type {
+  Extension,
+  LoadedExtension,
+  ResolvedExtension,
+  ExtensionPredicate,
+} from '../types/extension';
+import { consoleLogger } from '../utils/logger';
+import { settleAllPromises } from '../utils/promise';
+import { isExtensionCodeRefsResolutionError, resolveCodeRefValues } from './coderefs';
+import { usePluginManager } from './PluginStoreContext';
+import { useExtensions } from './useExtensions';
+
+type UseResolvedExtensionsResult<TExtension extends Extension> = [
+  resolvedExtensions: LoadedExtension<ResolvedExtension<TExtension>>[],
+  resolved: boolean,
+  errors: unknown[],
+];
+
+/**
+ * React hook that calls `useExtensions` and resolves all code references in all matching extensions.
+ *
+ * Resolving code references to the corresponding values is an asynchronous operation. Initially,
+ * this hook returns a pending result tuple `[resolvedExtensions: [], resolved: false, errors: []]`.
+ *
+ * Once the resolution is complete, this hook re-renders the component with a result tuple containing
+ * all matching extensions that had their code references resolved successfully along with any errors
+ * that occurred during the process.
+ *
+ * When the list of matching extensions changes, the resolution is restarted.
+ *
+ * The hook's result tuple elements are guaranteed to be referentially stable across re-renders.
+ *
+ * @see {@link useExtensions}
+ */
+export const useResolvedExtensions = <TExtension extends Extension>(
+  predicate?: ExtensionPredicate<TExtension>,
+): UseResolvedExtensionsResult<TExtension> => {
+  const extensions = useExtensions(predicate);
+  const pluginManager = usePluginManager();
+
+  const [resolvedExtensions, setResolvedExtensions] = React.useState<
+    LoadedExtension<ResolvedExtension<TExtension>>[]
+  >([]);
+
+  const [resolved, setResolved] = React.useState<boolean>(false);
+  const [errors, setErrors] = React.useState<unknown[]>([]);
+
+  React.useEffect(() => {
+    // eslint-disable-next-line promise/catch-or-return -- this Promise never rejects
+    settleAllPromises(extensions.map(resolveCodeRefValues)).then(
+      ([fulfilledValues, rejectedReasons]) => {
+        // eslint-disable-next-line promise/always-return -- this Promise is handled inline
+        if (rejectedReasons.length > 0) {
+          consoleLogger.error(
+            `useResolvedExtensions has detected ${rejectedReasons.length} errors`,
+            rejectedReasons,
+          );
+
+          const failedPluginNames = _.uniq(
+            rejectedReasons
+              .filter(isExtensionCodeRefsResolutionError)
+              .map((e) => e.extension.pluginName),
+          );
+
+          pluginManager.setPluginsEnabled(
+            failedPluginNames.map((pluginName) => ({ pluginName, enabled: false })),
+          );
+        }
+
+        setResolved(true);
+        setResolvedExtensions(fulfilledValues);
+        setErrors(rejectedReasons);
+      },
+    );
+  }, [extensions, pluginManager]);
+
+  return [resolvedExtensions, resolved, errors];
+};

--- a/packages/lib-runtime/src/types/store.ts
+++ b/packages/lib-runtime/src/types/store.ts
@@ -76,9 +76,9 @@ export type PluginManager = {
   loadPlugin: (baseURL: string) => void;
 
   /**
-   * Enable or disable the given plugin.
+   * Enable or disable the given plugins.
    *
-   * Enabling the plugin puts all of its extensions into use. Disabling it does the opposite.
+   * Enabling a plugin puts all of its extensions into use. Disabling it does the opposite.
    */
-  setPluginEnabled: (pluginName: string, enabled: boolean) => void;
+  setPluginsEnabled: (config: { pluginName: string; enabled: boolean }[]) => void;
 };

--- a/packages/lib-runtime/src/utils/promise.ts
+++ b/packages/lib-runtime/src/utils/promise.ts
@@ -1,0 +1,25 @@
+const isPromiseFulfilledResult = <T>(r: PromiseSettledResult<T>): r is PromiseFulfilledResult<T> =>
+  r.status === 'fulfilled';
+
+const isPromiseRejectedResult = (r: PromiseSettledResult<unknown>): r is PromiseRejectedResult =>
+  r.status === 'rejected';
+
+/**
+ * Unwrap the results of `Promise.allSettled()` call for easier processing.
+ */
+const unwrapPromiseSettledResults = <T>(
+  results: PromiseSettledResult<T>[],
+): [fulfilledValues: T[], rejectedReasons: unknown[]] => [
+  results.filter(isPromiseFulfilledResult).map((r) => r.value),
+  results.filter(isPromiseRejectedResult).map((r) => r.reason),
+];
+
+/**
+ * Await `Promise.allSettled(promises)` and unwrap the results.
+ *
+ * Note that the Promise returned by `Promise.allSettled()` never rejects.
+ */
+export const settleAllPromises = async <T>(promises: Promise<T>[]) => {
+  const results = await Promise.allSettled(promises);
+  return unwrapPromiseSettledResults(results);
+};


### PR DESCRIPTION
Fixes [HAC-447](https://issues.redhat.com/browse/HAC-447)

- add `useResolvedExtensions` React hook
- change `setPluginEnabled` method to `setPluginsEnabled` (allows changing enabled status for multiple plugins)
- ensure that `resolveCodeRefValues` clones the original extension's `properties` object
- use proper `isSameData` impl. in `useExtensions` React hook