### PR TITLE
HAC-423: Bring AppInitSDK into Core SDK

### DIFF
--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -22,15 +22,20 @@
     "test": "echo 'Write some tests!'"
   },
   "peerDependencies": {
+    "@openshift/dynamic-plugin-sdk": "^1.0.0",
     "lodash-es": "^4.17.21",
     "react": "^17.0.2",
     "react-redux": "^7.2.2",
-    "redux": "^4.0.3",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.4.1"
+  },
+  "dependencies": {
+    "immutable": "^3.8.2",
+    "typesafe-actions": "^4.4.2"
   },
   "devDependencies": {
     "@monorepo/common": "0.0.0-fixed",
-    "@openshift/dynamic-plugin-sdk": "1.0.0-alpha1",
+    "@openshift/dynamic-plugin-sdk": "link:../lib-core",
     "@rollup/plugin-node-resolve": "^13.1.1",
     "@rollup/plugin-typescript": "^8.3.0",
     "@types/lodash-es": "^4.17.5",
@@ -38,16 +43,12 @@
     "lodash-es": "^4.17.21",
     "react": "^17.0.2",
     "react-redux": "^7.2.2",
-    "redux": "^4.0.3",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.4.1",
     "rollup": "^2.61.1",
     "rollup-plugin-analyzer": "^4.0.0",
     "rollup-plugin-dts": "^4.0.1",
     "tslib": "^2.3.1",
     "typescript": "~4.4.4"
-  },
-  "dependencies": {
-    "immutable": "^3.8.2",
-    "typesafe-actions": "^4.4.2"
   }
 }

--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@monorepo/common": "0.0.0-fixed",
+    "@openshift/dynamic-plugin-sdk": "1.0.0-alpha1",
     "@rollup/plugin-node-resolve": "^13.1.1",
     "@rollup/plugin-typescript": "^8.3.0",
     "@types/lodash-es": "^4.17.5",

--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -23,7 +23,10 @@
   },
   "peerDependencies": {
     "lodash-es": "^4.17.21",
-    "react": "^17.0.2"
+    "react": "^17.0.2",
+    "react-redux": "^7.2.2",
+    "redux": "^4.0.3",
+    "redux-thunk": "^2.4.1"
   },
   "devDependencies": {
     "@monorepo/common": "0.0.0-fixed",
@@ -33,10 +36,17 @@
     "@types/react": "^17.0.37",
     "lodash-es": "^4.17.21",
     "react": "^17.0.2",
+    "react-redux": "^7.2.2",
+    "redux": "^4.0.3",
+    "redux-thunk": "^2.4.1",
     "rollup": "^2.61.1",
     "rollup-plugin-analyzer": "^4.0.0",
     "rollup-plugin-dts": "^4.0.1",
     "tslib": "^2.3.1",
     "typescript": "~4.4.4"
+  },
+  "dependencies": {
+    "immutable": "^3.8.2",
+    "typesafe-actions": "^4.4.2"
   }
 }

--- a/packages/lib-utils/src/app/AppInitSDK.tsx
+++ b/packages/lib-utils/src/app/AppInitSDK.tsx
@@ -7,12 +7,14 @@ import type { InitAPIDiscovery } from '../types/api-discovery';
 import { initAPIDiscovery } from './api-discovery';
 import { useReduxStore } from './redux';
 
-type AppInitSDKProps = React.PropsWithChildren<{
+type AppInitSDKProps = {
+  /** Only child is your Application */
+  children: React.ReactElement;
   configurations: {
     apiDiscovery?: InitAPIDiscovery;
     appFetch: UtilsConfig['appFetch'];
   };
-}>;
+};
 
 /**
  * Component for providing store access to the SDK.
@@ -25,8 +27,7 @@ type AppInitSDKProps = React.PropsWithChildren<{
  * return (
  *  <Provider store={store}>
  *   <AppInitSDK configurations={{ appFetch, apiDiscovery }}>
- *      <CustomApp />
- *      ...
+ *      <App />
  *   </AppInitSDK>
  *  </Provider>
  * )
@@ -34,18 +35,17 @@ type AppInitSDKProps = React.PropsWithChildren<{
  */
 const AppInitSDK: React.FC<AppInitSDKProps> = ({ children, configurations }) => {
   const { store, storeContextPresent } = useReduxStore();
+  const { appFetch, apiDiscovery = initAPIDiscovery } = configurations;
   React.useEffect(() => {
-    const { appFetch, apiDiscovery = initAPIDiscovery } = configurations;
     try {
       setUtilsConfig({ appFetch });
       apiDiscovery(store);
     } catch (e) {
       consoleLogger.warn(e);
     }
-  }, [configurations, store]);
+  }, [apiDiscovery, appFetch, store]);
 
-  // eslint-disable-next-line react/jsx-no-useless-fragment
-  return !storeContextPresent ? <Provider store={store}>{children}</Provider> : <>{children}</>;
+  return !storeContextPresent ? <Provider store={store}>{children}</Provider> : children;
 };
 
 export default AppInitSDK;

--- a/packages/lib-utils/src/app/AppInitSDK.tsx
+++ b/packages/lib-utils/src/app/AppInitSDK.tsx
@@ -1,0 +1,51 @@
+import { consoleLogger } from '@monorepo/common';
+import * as React from 'react';
+import { Provider } from 'react-redux';
+import type { UtilsConfig } from '../config';
+import { setUtilsConfig } from '../config';
+import type { InitAPIDiscovery } from '../types/api-discovery';
+import { initAPIDiscovery } from './api-discovery';
+import { useReduxStore } from './redux';
+
+type AppInitSDKProps = React.PropsWithChildren<{
+  configurations: {
+    apiDiscovery?: InitAPIDiscovery;
+    appFetch: UtilsConfig['appFetch'];
+  };
+}>;
+
+/**
+ * Component for providing store access to the SDK.
+ * Add this at app-level to make use of app's redux store and pass configurations prop needed to initialize the app, preferred to have it under Provider.
+ * It checks for store instance if present or not.
+ * If the store is there then the reference is persisted to be used in SDK else it creates a new store and passes it to the children with the provider
+ * @component AppInitSDK
+ * @example
+ * ```ts
+ * return (
+ *  <Provider store={store}>
+ *   <AppInitSDK configurations={{ appFetch, apiDiscovery }}>
+ *      <CustomApp />
+ *      ...
+ *   </AppInitSDK>
+ *  </Provider>
+ * )
+ * ```
+ */
+const AppInitSDK: React.FC<AppInitSDKProps> = ({ children, configurations }) => {
+  const { store, storeContextPresent } = useReduxStore();
+  React.useEffect(() => {
+    const { appFetch, apiDiscovery = initAPIDiscovery } = configurations;
+    try {
+      setUtilsConfig({ appFetch });
+      apiDiscovery(store);
+    } catch (e) {
+      consoleLogger.warn(e);
+    }
+  }, [configurations, store]);
+
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return !storeContextPresent ? <Provider store={store}>{children}</Provider> : <>{children}</>;
+};
+
+export default AppInitSDK;

--- a/packages/lib-utils/src/app/AppInitSDK.tsx
+++ b/packages/lib-utils/src/app/AppInitSDK.tsx
@@ -17,13 +17,13 @@ type AppInitSDKProps = {
 };
 
 /**
- * Component for providing store access to the SDK.
+ * Initializes the host application to work with Kubernetes and related SDK utilities.
  * Add this at app-level to make use of app's redux store and pass configurations prop needed to initialize the app, preferred to have it under Provider.
  * It checks for store instance if present or not.
  * If the store is there then the reference is persisted to be used in SDK else it creates a new store and passes it to the children with the provider
  * @component AppInitSDK
  * @example
- * ```ts
+ * ```tsx
  * return (
  *  <Provider store={store}>
  *   <AppInitSDK configurations={{ appFetch, apiDiscovery }}>
@@ -41,7 +41,7 @@ const AppInitSDK: React.FC<AppInitSDKProps> = ({ children, configurations }) => 
       setUtilsConfig({ appFetch });
       apiDiscovery(store);
     } catch (e) {
-      consoleLogger.warn(e);
+      consoleLogger.warn('Error while initializing AppInitSDK', e);
     }
   }, [apiDiscovery, appFetch, store]);
 

--- a/packages/lib-utils/src/app/api-discovery/index.ts
+++ b/packages/lib-utils/src/app/api-discovery/index.ts
@@ -1,0 +1,6 @@
+import type { InitAPIDiscovery } from '../../types/api-discovery';
+
+// TODO remove when API discovery is migrated
+export const initAPIDiscovery: InitAPIDiscovery = (storeInstance) => {
+  return storeInstance;
+};

--- a/packages/lib-utils/src/app/redux/index.ts
+++ b/packages/lib-utils/src/app/redux/index.ts
@@ -1,0 +1,43 @@
+import { consoleLogger } from '@monorepo/common';
+import * as React from 'react';
+import { useStore } from 'react-redux';
+import type { Store } from 'redux';
+import { applyMiddleware, combineReducers, createStore, compose } from 'redux';
+import thunk from 'redux-thunk';
+import { setReduxStore, getReduxStore } from '../../config';
+import type { SDKStoreState } from '../../types/redux';
+import { SDKReducers } from './reducers';
+
+/**
+ * `useReduxStore` will provide the store instance if present or else create one along with info if the context was present.
+ *
+ * @example
+ * ```ts
+ * function Component () {
+ *   const {store, storeContextPresent} = useReduxStore()
+ *   return ...
+ * }
+ * ```
+ */
+export const useReduxStore = (): { store: Store<unknown>; storeContextPresent: boolean } => {
+  const storeContext = useStore();
+  const [storeContextPresent, setStoreContextPresent] = React.useState(false);
+  const store = React.useMemo(() => {
+    if (storeContext) {
+      setStoreContextPresent(true);
+      setReduxStore(storeContext);
+    } else {
+      consoleLogger.info('Creating the SDK redux store');
+      setStoreContextPresent(false);
+      const storeInstance = createStore(
+        combineReducers<SDKStoreState>(SDKReducers),
+        {},
+        compose(applyMiddleware(thunk)),
+      );
+      setReduxStore(storeInstance);
+    }
+    return getReduxStore();
+  }, [storeContext]);
+
+  return { store, storeContextPresent };
+};

--- a/packages/lib-utils/src/app/redux/index.ts
+++ b/packages/lib-utils/src/app/redux/index.ts
@@ -8,6 +8,11 @@ import { setReduxStore, getReduxStore } from '../../config';
 import type { SDKStoreState } from '../../types/redux';
 import { SDKReducers } from './reducers';
 
+type UseReduxStoreResult = {
+  store: Store<unknown>;
+  storeContextPresent: boolean;
+};
+
 /**
  * `useReduxStore` will provide the store instance if present or else create one along with info if the context was present.
  *
@@ -19,7 +24,7 @@ import { SDKReducers } from './reducers';
  * }
  * ```
  */
-export const useReduxStore = (): { store: Store<unknown>; storeContextPresent: boolean } => {
+export const useReduxStore = (): UseReduxStoreResult => {
   const storeContext = useStore();
   const [storeContextPresent, setStoreContextPresent] = React.useState(false);
   const store = React.useMemo(() => {

--- a/packages/lib-utils/src/app/redux/reducers/core/index.ts
+++ b/packages/lib-utils/src/app/redux/reducers/core/index.ts
@@ -1,0 +1,14 @@
+import type { ActionType as Action } from 'typesafe-actions';
+import type { CoreState } from '../../../../types/redux';
+
+// TODO remove when actions/reducers are migrated
+const emptyCoreState: CoreState = {
+  user: { apiVersion: '', kind: '', identities: [] },
+  activeCluster: '',
+};
+
+type CoreAction = Action<typeof Object>;
+
+export const coreReducer = (state: CoreState | undefined, action: CoreAction): CoreState => {
+  return state || action ? emptyCoreState : emptyCoreState;
+};

--- a/packages/lib-utils/src/app/redux/reducers/index.ts
+++ b/packages/lib-utils/src/app/redux/reducers/index.ts
@@ -1,0 +1,13 @@
+import { coreReducer } from './core';
+import { sdkK8sReducer } from './k8s';
+
+/**
+ * Dynamic Plugin SDK Redux store reducers
+ *
+ * If the app uses Redux, these can be spread into the root of your store to provide an integrated SDK.
+ * If the app does not use Redux, these will be provided via the SDK Redux Store.
+ */
+export const SDKReducers = Object.freeze({
+  sdkCore: coreReducer,
+  k8s: sdkK8sReducer,
+});

--- a/packages/lib-utils/src/app/redux/reducers/k8s/index.ts
+++ b/packages/lib-utils/src/app/redux/reducers/k8s/index.ts
@@ -1,0 +1,15 @@
+import { Map as ImmutableMap, fromJS } from 'immutable';
+import type { ActionType as Action } from 'typesafe-actions';
+import type { K8sModelCommon } from '../../../../types/k8s';
+import type { K8sState } from '../../../../types/redux';
+
+// TODO remove when actions/reducers are migrated
+const emptyK8sState: K8sState = fromJS({
+  RESOURCES: { inFlight: false, models: ImmutableMap<string, K8sModelCommon>() },
+});
+
+type K8sAction = Action<typeof Object>;
+
+export const sdkK8sReducer = (state: K8sState | undefined, action: K8sAction): K8sState => {
+  return state || action ? emptyK8sState : emptyK8sState;
+};

--- a/packages/lib-utils/src/config.ts
+++ b/packages/lib-utils/src/config.ts
@@ -1,4 +1,5 @@
 import type { ResourceFetch } from '@monorepo/common';
+import type { Store } from 'redux';
 
 export type UtilsConfig = {
   /**
@@ -38,4 +39,28 @@ export const getUtilsConfig = () => {
   }
 
   return config;
+};
+
+let reduxStore: Store;
+
+/**
+ * Set the {@link Store} reference.
+ *
+ * This must be done before using the AppInitSDK React entrypoint
+ */
+export const setReduxStore = (storeData: Store) => {
+  reduxStore = storeData;
+};
+
+/**
+ * Get the {@link Store} reference.
+ *
+ * Throws an error if the reference isn't already set.
+ */
+export const getReduxStore = () => {
+  if (reduxStore === undefined) {
+    throw new Error('Redux store reference has not been set');
+  }
+
+  return reduxStore;
 };

--- a/packages/lib-utils/src/types/api-discovery.ts
+++ b/packages/lib-utils/src/types/api-discovery.ts
@@ -1,0 +1,19 @@
+import type { Store, AnyAction } from 'redux';
+import type { ActionType as Action } from 'typesafe-actions';
+import type { K8sVerb } from './k8s';
+
+export type InitAPIDiscovery = (store: Store<unknown, Action<AnyAction>>) => void;
+
+export type APIResourceList = {
+  kind: 'APIResourceList';
+  apiVersion: 'v1';
+  groupVersion: string;
+  resources?: {
+    name: string;
+    singularName?: string;
+    namespaced?: boolean;
+    kind: string;
+    verbs: K8sVerb[];
+    shortNames?: string[];
+  }[];
+};

--- a/packages/lib-utils/src/types/api-discovery.ts
+++ b/packages/lib-utils/src/types/api-discovery.ts
@@ -1,13 +1,13 @@
+import type { K8sVerb } from '@openshift/dynamic-plugin-sdk/src/types/core';
 import type { Store, AnyAction } from 'redux';
 import type { ActionType as Action } from 'typesafe-actions';
-import type { K8sVerb } from './k8s';
+import type { K8sModelCommon } from './k8s';
 
 export type InitAPIDiscovery = (store: Store<unknown, Action<AnyAction>>) => void;
 
-export type APIResourceList = {
+export type APIResourceList = K8sModelCommon & {
   kind: 'APIResourceList';
   apiVersion: 'v1';
-  groupVersion: string;
   resources?: {
     name: string;
     singularName?: string;

--- a/packages/lib-utils/src/types/k8s.ts
+++ b/packages/lib-utils/src/types/k8s.ts
@@ -58,13 +58,3 @@ export type Patch = {
   path: string;
   value?: unknown;
 };
-
-export type K8sVerb =
-  | 'create'
-  | 'get'
-  | 'list'
-  | 'update'
-  | 'patch'
-  | 'delete'
-  | 'deletecollection'
-  | 'watch';

--- a/packages/lib-utils/src/types/k8s.ts
+++ b/packages/lib-utils/src/types/k8s.ts
@@ -58,3 +58,13 @@ export type Patch = {
   path: string;
   value?: unknown;
 };
+
+export type K8sVerb =
+  | 'create'
+  | 'get'
+  | 'list'
+  | 'update'
+  | 'patch'
+  | 'delete'
+  | 'deletecollection'
+  | 'watch';

--- a/packages/lib-utils/src/types/redux.ts
+++ b/packages/lib-utils/src/types/redux.ts
@@ -1,0 +1,26 @@
+import type { Map as ImmutableMap } from 'immutable';
+import type { K8sResourceCommon } from './k8s';
+
+export type K8sState = ImmutableMap<string, unknown>;
+
+export type UserKind = {
+  fullName?: string;
+  identities: string[];
+} & K8sResourceCommon;
+
+export type ImpersonateKind = {
+  kind: string;
+  name: string;
+  subprotocols: string[];
+};
+
+export type CoreState = {
+  activeCluster?: string;
+  user?: UserKind;
+  impersonate?: ImpersonateKind;
+};
+
+export type SDKStoreState = {
+  sdkCore: CoreState;
+  k8s: K8sState;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -215,16 +215,24 @@ __metadata:
     "@rollup/plugin-typescript": ^8.3.0
     "@types/lodash-es": ^4.17.5
     "@types/react": ^17.0.37
+    immutable: ^3.8.2
     lodash-es: ^4.17.21
     react: ^17.0.2
+    react-redux: ^7.2.2
+    redux: ^4.0.3
+    redux-thunk: ^2.4.1
     rollup: ^2.61.1
     rollup-plugin-analyzer: ^4.0.0
     rollup-plugin-dts: ^4.0.1
     tslib: ^2.3.1
+    typesafe-actions: ^4.4.2
     typescript: ~4.4.4
   peerDependencies:
     lodash-es: ^4.17.21
     react: ^17.0.2
+    react-redux: ^7.2.2
+    redux: ^4.0.3
+    redux-thunk: ^2.4.1
   languageName: unknown
   linkType: soft
 
@@ -319,6 +327,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/hoist-non-react-statics@npm:^3.3.0":
+  version: 3.3.1
+  resolution: "@types/hoist-non-react-statics@npm:3.3.1"
+  dependencies:
+    "@types/react": "*"
+    hoist-non-react-statics: ^3.3.0
+  checksum: 2c0778570d9a01d05afabc781b32163f28409bb98f7245c38d5eaf082416fdb73034003f5825eb5e21313044e8d2d9e1f3fe2831e345d3d1b1d20bcd12270719
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.9":
   version: 7.0.9
   resolution: "@types/json-schema@npm:7.0.9"
@@ -367,6 +385,18 @@ __metadata:
   version: 15.7.4
   resolution: "@types/prop-types@npm:15.7.4"
   checksum: ef6e1899e59b876c273811b1bd845022fc66d5a3d11cb38a25b6c566b30514ae38fe20a40f67622f362a4f4f7f9224e22d8da101cff3d6e97e11d7b4c307cfc1
+  languageName: node
+  linkType: hard
+
+"@types/react-redux@npm:^7.1.20":
+  version: 7.1.22
+  resolution: "@types/react-redux@npm:7.1.22"
+  dependencies:
+    "@types/hoist-non-react-statics": ^3.3.0
+    "@types/react": "*"
+    hoist-non-react-statics: ^3.3.0
+    redux: ^4.0.0
+  checksum: eef458c0cda27eabd8d458b7fc40553aab8d2f218145b896b9059b86d88680ae479079aee13683f2a0f35774f20346b732e91182252402bd8777455e004561c9
   languageName: node
   linkType: hard
 
@@ -1821,6 +1851,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "hoist-non-react-statics@npm:3.3.2"
+  dependencies:
+    react-is: ^16.7.0
+  checksum: b1538270429b13901ee586aa44f4cc3ecd8831c061d06cb8322e50ea17b3f5ce4d0e2e66394761e6c8e152cd8c34fb3b4b690116c6ce2bd45b18c746516cb9e8
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.0":
   version: 4.1.0
   resolution: "http-cache-semantics@npm:4.1.0"
@@ -1878,6 +1917,13 @@ __metadata:
   version: 5.1.9
   resolution: "ignore@npm:5.1.9"
   checksum: 6f6b2235f4e63648116c5814f76b2d3d63fae9c21b8a466862e865732f59e787c9938a9042f9457091db6f0d811508ea3c8c6a60f35bafc4ceea08bbe8f96fd5
+  languageName: node
+  linkType: hard
+
+"immutable@npm:^3.8.2":
+  version: 3.8.2
+  resolution: "immutable@npm:3.8.2"
+  checksum: 41909b386950ff84ca3cfca77c74cfc87d225a914e98e6c57996fa81a328da61a7c32216d6d5abad40f54747ffdc5c4b02b102e6ad1a504c1752efde8041f964
   languageName: node
   linkType: hard
 
@@ -2751,10 +2797,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.8.1":
+"react-is@npm:^16.7.0, react-is@npm:^16.8.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^17.0.2":
+  version: 17.0.2
+  resolution: "react-is@npm:17.0.2"
+  checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
+  languageName: node
+  linkType: hard
+
+"react-redux@npm:^7.2.2":
+  version: 7.2.6
+  resolution: "react-redux@npm:7.2.6"
+  dependencies:
+    "@babel/runtime": ^7.15.4
+    "@types/react-redux": ^7.1.20
+    hoist-non-react-statics: ^3.3.2
+    loose-envify: ^1.4.0
+    prop-types: ^15.7.2
+    react-is: ^17.0.2
+  peerDependencies:
+    react: ^16.8.3 || ^17
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: 0bf142ce0d0b80aef955650fd5e9489fca32d94f19ee23893b332f1b01ceee7bd3623337c942cbda642667d1dc9de5ac869c3c1946afa6cf2046407b57d24741
   languageName: node
   linkType: hard
 
@@ -2779,7 +2853,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux@npm:^4.1.2":
+"redux-thunk@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "redux-thunk@npm:2.4.1"
+  peerDependencies:
+    redux: ^4
+  checksum: af5abb425fb9dccda02e5f387d6f3003997f62d906542a3d35fc9420088f550dc1a018bdc246c7d23ee852b4d4ab8b5c64c5be426e45a328d791c4586a3c6b6e
+  languageName: node
+  linkType: hard
+
+"redux@npm:^4.0.0, redux@npm:^4.0.3, redux@npm:^4.1.2":
   version: 4.1.2
   resolution: "redux@npm:4.1.2"
   dependencies:
@@ -3278,6 +3361,13 @@ __metadata:
   version: 0.20.2
   resolution: "type-fest@npm:0.20.2"
   checksum: 4fb3272df21ad1c552486f8a2f8e115c09a521ad7a8db3d56d53718d0c907b62c6e9141ba5f584af3f6830d0872c521357e512381f24f7c44acae583ad517d73
+  languageName: node
+  linkType: hard
+
+"typesafe-actions@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "typesafe-actions@npm:4.4.2"
+  checksum: 43b3a91af74172b42e27098150d84eaa9f02f74a8f9c81225e560d48872f6a3174482651d6e6278f380ed25870edb2b949b4776382cf0393b8299a3723c56d9b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,7 +211,7 @@ __metadata:
   resolution: "@openshift/dynamic-plugin-sdk-utils@workspace:packages/lib-utils"
   dependencies:
     "@monorepo/common": 0.0.0-fixed
-    "@openshift/dynamic-plugin-sdk": 1.0.0-alpha1
+    "@openshift/dynamic-plugin-sdk": "link:../lib-core"
     "@rollup/plugin-node-resolve": ^13.1.1
     "@rollup/plugin-typescript": ^8.3.0
     "@types/lodash-es": ^4.17.5
@@ -220,7 +220,7 @@ __metadata:
     lodash-es: ^4.17.21
     react: ^17.0.2
     react-redux: ^7.2.2
-    redux: ^4.0.3
+    redux: ^4.1.2
     redux-thunk: ^2.4.1
     rollup: ^2.61.1
     rollup-plugin-analyzer: ^4.0.0
@@ -229,15 +229,22 @@ __metadata:
     typesafe-actions: ^4.4.2
     typescript: ~4.4.4
   peerDependencies:
+    "@openshift/dynamic-plugin-sdk": ^1.0.0
     lodash-es: ^4.17.21
     react: ^17.0.2
     react-redux: ^7.2.2
-    redux: ^4.0.3
+    redux: ^4.1.2
     redux-thunk: ^2.4.1
   languageName: unknown
   linkType: soft
 
-"@openshift/dynamic-plugin-sdk@1.0.0-alpha1, @openshift/dynamic-plugin-sdk@workspace:packages/lib-core":
+"@openshift/dynamic-plugin-sdk@link:../lib-core::locator=%40openshift%2Fdynamic-plugin-sdk-utils%40workspace%3Apackages%2Flib-utils":
+  version: 0.0.0-use.local
+  resolution: "@openshift/dynamic-plugin-sdk@link:../lib-core::locator=%40openshift%2Fdynamic-plugin-sdk-utils%40workspace%3Apackages%2Flib-utils"
+  languageName: node
+  linkType: soft
+
+"@openshift/dynamic-plugin-sdk@workspace:packages/lib-core":
   version: 0.0.0-use.local
   resolution: "@openshift/dynamic-plugin-sdk@workspace:packages/lib-core"
   dependencies:
@@ -2863,7 +2870,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux@npm:^4.0.0, redux@npm:^4.0.3, redux@npm:^4.1.2":
+"redux@npm:^4.0.0, redux@npm:^4.1.2":
   version: 4.1.2
   resolution: "redux@npm:4.1.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,6 +211,7 @@ __metadata:
   resolution: "@openshift/dynamic-plugin-sdk-utils@workspace:packages/lib-utils"
   dependencies:
     "@monorepo/common": 0.0.0-fixed
+    "@openshift/dynamic-plugin-sdk": 1.0.0-alpha1
     "@rollup/plugin-node-resolve": ^13.1.1
     "@rollup/plugin-typescript": ^8.3.0
     "@types/lodash-es": ^4.17.5
@@ -236,7 +237,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openshift/dynamic-plugin-sdk@workspace:packages/lib-core":
+"@openshift/dynamic-plugin-sdk@1.0.0-alpha1, @openshift/dynamic-plugin-sdk@workspace:packages/lib-core":
   version: 0.0.0-use.local
   resolution: "@openshift/dynamic-plugin-sdk@workspace:packages/lib-core"
   dependencies:


### PR DESCRIPTION
Migrates the AppInitSDK logic into the HAC dynamic plugin SDK. Does not migrate the api discovery logic nor actions/reducers required by the AppInitSDK logic.

See https://issues.redhat.com/browse/HAC-423