### PR TITLE
Move in extension types

### DIFF
--- a/packages/lib-core/package.json
+++ b/packages/lib-core/package.json
@@ -24,6 +24,7 @@
   "peerDependencies": {
     "lodash-es": "^4.17.21",
     "react": "^17.0.2",
+    "redux": "^4.1.2",
     "yup": "^0.32.11"
   },
   "devDependencies": {
@@ -32,8 +33,10 @@
     "@rollup/plugin-typescript": "^8.3.0",
     "@types/lodash-es": "^4.17.5",
     "@types/react": "^17.0.37",
+    "@types/react-router-dom": "^5.1.2",
     "lodash-es": "^4.17.21",
     "react": "^17.0.2",
+    "redux": "^4.1.2",
     "rollup": "^2.61.1",
     "rollup-plugin-analyzer": "^4.0.0",
     "rollup-plugin-dts": "^4.0.1",

--- a/packages/lib-core/src/extensions/actions.ts
+++ b/packages/lib-core/src/extensions/actions.ts
@@ -1,0 +1,128 @@
+import type { ReactNode } from 'react';
+import type { ExtensionK8sResourceIdentifier, ExtensionHook } from '../types/common';
+import type { CodeRef, Extension } from '../types/extension';
+
+/** ActionProvider contributes a hook that returns list of actions for specific context */
+export type ActionProvider = Extension<
+  'core.action/provider',
+  {
+    /** The context ID helps to narrow the scope of contributed actions to a particular area of the application. Ex - topology, helm */
+    contextId: string;
+    /**
+     * A react hook which returns actions for the given scope.
+     * If contextId = `resource` then the scope will always be a K8s resource object
+     */
+    provider: CodeRef<ExtensionHook<Action[]>>;
+  }
+>;
+
+/** ResourceActionProvider contributes a hook that returns list of actions for specific resource model */
+export type ResourceActionProvider = Extension<
+  'core.action/resource-provider',
+  {
+    /** The model for which this provider provides actions for. */
+    model: ExtensionK8sResourceIdentifier & {
+      version: string;
+      kind: string;
+    };
+    /** A react hook which returns actions for the given resource model */
+    provider: CodeRef<ExtensionHook<Action[]>>;
+  }
+>;
+
+/** ActionGroup contributes an action group that can also be a submenu */
+export type ActionGroup = Extension<'core.action/group', Group>;
+
+/** ActionFilter can be used to filter an action */
+export type ActionFilter = Extension<
+  'core.action/filter',
+  {
+    /** The context ID helps to narrow the scope of contributed actions to a particular area of the application. Ex - topology, helm */
+    contextId: string;
+    /**
+     * A function which will filter actions based on some conditions.
+     * scope: The scope in which actions should be provided for.
+     * Note: hook may be required if we want to remove the ModifyCount action from a deployment with HPA
+     */
+    filter: CodeRef<(scope: unknown, action: Action) => boolean>;
+  }
+>;
+
+// Type guards
+
+export const isActionProvider = (e: Extension): e is ActionProvider => {
+  return e.type === 'core.action/provider';
+};
+
+export const isResourceActionProvider = (e: Extension): e is ResourceActionProvider => {
+  return e.type === 'core.action/resource-provider';
+};
+
+export const isActionGroup = (e: Extension): e is ActionGroup => {
+  return e.type === 'core.action/group';
+};
+
+export const isActionFilter = (e: Extension): e is ActionFilter => {
+  return e.type === 'core.action/filter';
+};
+
+// Arbitrary types
+
+type Group = {
+  /** ID used to identify the action section. */
+  id: string;
+  /**
+   * The label to display in the UI.
+   * Required for submenus.
+   */
+  label?: string;
+  /** Whether this group should be displayed as submenu */
+  submenu?: boolean;
+  /**
+   * Insert this item before the item referenced here.
+   * For arrays, the first one found in order is used.
+   */
+  insertBefore?: string | string[];
+  /**
+   Insert this item after the item referenced here.
+   * For arrays, the first one found in order is used.
+   * insertBefore takes precedence.
+   */
+  insertAfter?: string | string[];
+};
+
+type Action = {
+  /** A unique identifier for this action. */
+  id: string;
+  /** The label to display in the UI. */
+  label: ReactNode;
+  /** Subtext for the menu item */
+  description?: string;
+  /**
+   * Executable callback or href.
+   * External links should automatically provide an external link icon on action.
+   */
+  cta: (() => void) | { href: string; external?: boolean };
+  /** Whether the action is disabled. */
+  disabled?: boolean;
+  /** The tooltip for this action. */
+  tooltip?: string | ReactNode;
+  /** The icon for this action. */
+  icon?: string | ReactNode;
+  /**
+   * A `/` separated string where each segment denotes
+   * Eg. `add-to-project`, `menu-1/menu-2`
+   */
+  path?: string;
+  /**
+   * Insert this item before the item referenced here.
+   * For arrays, the first one found in order is used.
+   */
+  insertBefore?: string | string[];
+  /**
+   * Insert this item after the item referenced here.
+   * For arrays, the first one found in order is used.
+   * insertBefore takes precedence.
+   */
+  insertAfter?: string | string[];
+};

--- a/packages/lib-core/src/extensions/catalog.ts
+++ b/packages/lib-core/src/extensions/catalog.ts
@@ -1,0 +1,145 @@
+import type { AnyObject } from '@monorepo/common';
+import type { ReactNode } from 'react';
+import type { ExtensionHook } from '../types/common';
+import type { Extension, CodeRef } from '../types/extension';
+
+export type CatalogItemType = Extension<
+  'core.catalog/item-type',
+  TypeAndTitle & {
+    /** Description for the type specific catalog. */
+    catalogDescription?: string;
+    /** Description for the catalog item type. */
+    typeDescription?: string;
+    /** Custom filters specific to the catalog item.  */
+    filters?: CatalogItemAttribute[];
+    /** Custom groupings specific to the catalog item. */
+    groupings?: CatalogItemAttribute[];
+  }
+>;
+
+export type CatalogItemProvider = Extension<
+  'core.catalog/item-provider',
+  TypeAndTitle & {
+    /** The unique identifier for the catalog this provider contributes to. */
+    catalogId: string | string[];
+    /** Fetch items and normalize it for the catalog. Value is a react effect hook. */
+    provider: CodeRef<ExtensionHook<CatalogItem[], CatalogExtensionHookOptions>>;
+    /** Priority for this provider. Defaults to 0. Higher priority providers may override catalog
+        items provided by other providers. */
+    priority?: number;
+  }
+>;
+
+export type CatalogItemFilter = Extension<
+  'core.catalog/item-filter',
+  {
+    /** The unique identifier for the catalog this provider contributes to. */
+    catalogId: string | string[];
+    /** Type ID for the catalog item type. */
+    type: string;
+    /** Filters items of a specific type. Value is a function that takes CatalogItem[] and returns a subset based on the filter criteria. */
+    filter: CodeRef<(item: CatalogItem) => boolean>;
+  }
+>;
+
+// Type guards
+
+export const isCatalogItemType = (e: Extension): e is CatalogItemType => {
+  return e.type === 'core.catalog/item-type';
+};
+
+export const isCatalogItemProvider = (e: Extension): e is CatalogItemProvider => {
+  return e.type === 'core.catalog/item-provider';
+};
+
+export const isCatalogItemFilter = (e: Extension): e is CatalogItemFilter => {
+  return e.type === 'core.catalog/item-filter';
+};
+
+export type CatalogItem<TData extends AnyObject = AnyObject> = {
+  uid: string;
+  type: string;
+  name: string;
+  /** Optional title to render a custom title using ReactNode.
+   * Rendered in catalog tile and side panel
+   *  */
+  title?: string | ReactNode;
+  // Used as the second label next to the provider label in the list result.
+  secondaryLabel?: string | ReactNode;
+  provider?: string;
+  // Used as the tile description. If provided as a string, the description is truncated to 3 lines.
+  // If provided as a ReactNode, the contents will not be truncated.
+  // This description will also be shown in the side panel if there are no `details.descriptions`.
+  description?: string | ReactNode;
+  tags?: string[];
+  creationTimestamp?: string;
+  supportUrl?: string;
+  documentationUrl?: string;
+  attributes?: AnyObject;
+  cta?: {
+    label: string;
+    href?: string;
+    callback?: (props?: AnyObject) => void;
+  };
+  icon?: {
+    url?: string;
+    class?: string;
+    node?: string | ReactNode;
+  };
+  details?: CatalogItemDetails;
+  // Optional text only badges for the catalog item which will be rendered on the tile and details panel.
+  badges?: CatalogItemBadge[];
+  // Optional data attached by the provider.
+  // May be consumed by filters.
+  // `data` for each `type` of CatalogItem should implement the same interface.
+  data?: TData;
+};
+
+export type CatalogExtensionHookOptions = {
+  namespace: string;
+};
+
+export type ItemType = TypeAndTitle & {
+  /** Description for the type specific catalog. */
+  catalogDescription?: string;
+  /** Description for the catalog item type. */
+  typeDescription?: string;
+  /** Custom filters specific to the catalog item.  */
+  filters?: CatalogItemAttribute[];
+  /** Custom groupings specific to the catalog item. */
+  groupings?: CatalogItemAttribute[];
+};
+
+export type CatalogItemAttribute = {
+  label: string;
+  attribute: string;
+};
+
+export type CatalogItemBadge = {
+  text: string;
+  color?: 'blue' | 'cyan' | 'green' | 'orange' | 'purple' | 'red' | 'grey';
+  icon?: ReactNode;
+  variant?: 'outline' | 'filled';
+};
+
+export type CatalogItemDetails = {
+  properties?: CatalogItemDetailsProperty[];
+  descriptions?: CatalogItemDetailsDescription[];
+};
+
+export type CatalogItemDetailsProperty = {
+  label: string;
+  value: string | ReactNode;
+};
+
+export type CatalogItemDetailsDescription = {
+  label?: string;
+  value: string | ReactNode;
+};
+
+type TypeAndTitle = {
+  /** Type ID for the item type. */
+  type: string;
+  /** Title for the item */
+  title: string | ReactNode;
+};

--- a/packages/lib-core/src/extensions/context-providers.ts
+++ b/packages/lib-core/src/extensions/context-providers.ts
@@ -1,0 +1,18 @@
+import type { Provider } from 'react';
+import type { CodeRef, Extension } from '../types/extension';
+
+/** Adds new React context provider to Console application root. */
+export type ContextProvider<TValue = unknown> = Extension<
+  'core.context-provider',
+  {
+    /** Context Provider component. */
+    provider: CodeRef<Provider<TValue>>;
+    /** Hook for the Context value. */
+    useValueHook: CodeRef<() => TValue>;
+  }
+>;
+
+// Type guards
+
+export const isContextProvider = (e: Extension): e is ContextProvider =>
+  e.type === 'core.context-provider';

--- a/packages/lib-core/src/extensions/feature-flags.ts
+++ b/packages/lib-core/src/extensions/feature-flags.ts
@@ -1,0 +1,36 @@
+import type { ExtensionK8sResourceIdentifier } from '../types/common';
+import type { CodeRef, Extension } from '../types/extension';
+
+/** Gives full control over host application's feature flags. */
+export type FeatureFlag = Extension<
+  'core.flag',
+  {
+    /** Used to set/unset arbitrary feature flags. */
+    handler: CodeRef<(callback: SetFeatureFlag) => void>;
+  }
+>;
+
+/** Adds new feature flag to host application driven by the presence of a CRD on the cluster. */
+export type ModelFeatureFlag = Extension<
+  'core.flag/model',
+  {
+    /** The name of the flag to set once the CRD is detected. */
+    flag: string;
+    /** The model which refers to a `CustomResourceDefinition`. */
+    model: ExtensionK8sResourceIdentifier & {
+      group: string;
+      version: string;
+      kind: string;
+    };
+  }
+>;
+
+// Type guards
+
+export const isFeatureFlag = (e: Extension): e is FeatureFlag => e.type === 'core.flag';
+export const isModelFeatureFlag = (e: Extension): e is ModelFeatureFlag =>
+  e.type === 'core.flag/model';
+
+// Arbitrary types
+
+export type SetFeatureFlag = (flag: string, enabled: boolean) => void;

--- a/packages/lib-core/src/extensions/model-metadata.ts
+++ b/packages/lib-core/src/extensions/model-metadata.ts
@@ -1,0 +1,29 @@
+import type { ExtensionK8sResourceIdentifier } from '../types/common';
+import type { Extension } from '../types/extension';
+
+/** Customize the display of models by overriding values retrieved and generated through API discovery. */
+export type ModelMetadata = Extension<'core.model-metadata', Metatdata>;
+
+// Type guards
+
+export const isModelMetadata = (e: Extension): e is ModelMetadata =>
+  e.type === 'core.model-metadata';
+
+// Arbitrary types
+
+export type Metatdata = {
+  /** The model to customize. May specify only a group, or optional version and kind. */
+  model: ExtensionK8sResourceIdentifier & {
+    group: string;
+  };
+  /** Whether to consider this model reference as tech preview or dev preview. */
+  badge?: 'tech' | 'dev';
+  /** The color to associate to this model. */
+  color?: string;
+  /** Override the label. Requires `kind` be provided. */
+  label?: string;
+  /** Override the plural label. Requires `kind` be provided. */
+  labelPlural?: string;
+  /** Customize the abbreviation. Defaults to All uppercase chars in the kind up to 4 characters long. Requires `kind` be provided. */
+  abbr?: string;
+};

--- a/packages/lib-core/src/extensions/navigations.ts
+++ b/packages/lib-core/src/extensions/navigations.ts
@@ -1,0 +1,68 @@
+import type { ExtensionK8sResourceIdentifier } from '../types/common';
+import type { Extension } from '../types/extension';
+
+export type NavItem = Extension<
+  'core.navigation/href',
+  NavItemProperties & {
+    name: string;
+  }
+>;
+
+export type HrefNavItem = Extension<
+  'core.navigation/href',
+  NavItemProperties & {
+    /** The name of this item. */
+    name: string;
+    /** The link href value. */
+    href: string;
+    /** if true, adds /ns/active-namespace to the end */
+    namespaced?: boolean;
+    /** if true, adds /k8s/ns/active-namespace to the begining */
+    prefixNamespaced?: boolean;
+  }
+>;
+
+export type ResourceNSNavItem = Extension<
+  'core.navigation/resource-ns',
+  NavItemProperties & {
+    /** The model for which this nav item links to. */
+    model: ExtensionK8sResourceIdentifier & {
+      group: string;
+      version: string;
+      kind: string;
+    };
+  }
+>;
+
+export type Separator = Extension<
+  'core.navigation/separator',
+  Omit<NavItemProperties, 'startsWith'>
+>;
+
+// Type guards
+
+export const isHrefNavItem = (e: Extension): e is HrefNavItem => e.type === 'core.navigation/href';
+export const isResourceNSNavItem = (e: Extension): e is ResourceNSNavItem =>
+  e.type === 'core.navigation/resource-ns';
+export const isSeparator = (e: Extension): e is Separator => e.type === 'core.navigation/separator';
+
+// Arbitrary types
+
+export type NavItemProperties = {
+  /** A unique identifier for this item. */
+  id: string;
+  /** The name of this item. If not supplied the name of the link will equal the plural value of the model. */
+  name?: string;
+  /** The perspective ID to which this item belongs to. If not specified, contributes to the default perspective. */
+  perspective?: string;
+  /** Navigation section to which this item belongs to. If not specified, render this item as a top level link. */
+  section?: string;
+  /** Adds data attributes to the DOM. */
+  dataAttributes?: { [key: string]: string };
+  /** Mark this item as active when the URL starts with one of these paths. */
+  startsWith?: string[];
+  /** Insert this item before the item referenced here. For arrays, the first one found in order is used. */
+  insertBefore?: string | string[];
+  /** Insert this item after the item referenced here. For arrays, the first one found in order is used. `insertBefore` takes precedence. */
+  insertAfter?: string | string[];
+};

--- a/packages/lib-core/src/extensions/pages.ts
+++ b/packages/lib-core/src/extensions/pages.ts
@@ -1,0 +1,56 @@
+import type { ComponentType } from 'react';
+import type { RouteComponentProps } from 'react-router';
+import type { ExtensionK8sResourceIdentifier } from '../types/common';
+import type { CodeRef, Extension } from '../types/extension';
+
+/** Adds new page to host application's React router. */
+export type RoutePage = Extension<'core.page/route', RoutePageProperties>;
+
+/** Adds new resource list page to host application's React router. */
+export type ResourceListPage = Extension<'core.page/resource/list', ResourcePageProperties>;
+
+/** Adds new resource details page to host application's React router. */
+export type ResourceDetailsPage = Extension<'core.page/resource/details', ResourcePageProperties>;
+
+// Type guards
+
+export const isRoutePage = (e: Extension): e is RoutePage => e.type === 'core.page/route';
+export const isResourceListPage = (e: Extension): e is ResourceListPage =>
+  e.type === 'core.page/resource/list';
+export const isResourceDetailsPage = (e: Extension): e is ResourceDetailsPage =>
+  e.type === 'core/Resource/details';
+
+// Arbitrary types
+
+export type RoutePageProperties = {
+  /** The perspective to which this page belongs to. If not specified, contributes to all perspectives. */
+  perspective?: string;
+  /** The component to be rendered when the route matches. */
+  component: CodeRef<ComponentType<RouteComponentProps>>;
+  /** Valid URL path or array of paths that `path-to-regexp@^1.7.0` understands. */
+  path: string | string[];
+  /** When true, will only match if the path matches the `location.pathname` exactly. */
+  exact?: boolean;
+};
+
+export type ResourcePageProperties = {
+  /** The model for which this resource page links to. */
+  model: ExtensionK8sResourceIdentifier & {
+    group: string;
+    kind: string;
+  };
+  /** The component to be rendered when the route matches. */
+  component: CodeRef<
+    ComponentType<{
+      match: RouteComponentProps['match'];
+      /** The namespace for which this resource page links to. */
+      namespace: string;
+      /** The model for which this resource page links to. */
+      model: ExtensionK8sResourceIdentifier & {
+        group: string;
+        version: string;
+        kind: string;
+      };
+    }>
+  >;
+};

--- a/packages/lib-core/src/extensions/redux.ts
+++ b/packages/lib-core/src/extensions/redux.ts
@@ -1,0 +1,17 @@
+import type { Reducer } from 'redux';
+import type { CodeRef, Extension } from '../types/extension';
+
+/** Adds new reducer to host application's Redux store which operates on `plugins.<scope>` substate. */
+export type ReduxReducer = Extension<
+  'core.redux-reducer',
+  {
+    /** The key to represent the reducer-managed substate within the Redux state object. */
+    scope: string;
+    /** The reducer function, operating on the reducer-managed substate. */
+    reducer: CodeRef<Reducer>;
+  }
+>;
+
+// Type guards
+
+export const isReduxReducer = (e: Extension): e is ReduxReducer => e.type === 'core.redux-reducer';

--- a/packages/lib-core/src/extensions/resources.ts
+++ b/packages/lib-core/src/extensions/resources.ts
@@ -1,0 +1,27 @@
+import type { ComponentType } from 'react';
+import type { ExtensionK8sResourceIdentifier } from '../types/common';
+import type { CodeRef, Extension } from '../types/extension';
+
+export type CreateResource = Extension<
+  'core.resource/create',
+  {
+    /** The model for which this create resource page will be rendered. */
+    model: ExtensionK8sResourceIdentifier & {
+      group: string;
+      version: string;
+      kind: string;
+    };
+    /** The component to be rendered when the model matches */
+    component: CodeRef<ComponentType<CreateResourceComponentProps>>;
+  }
+>;
+
+// Type guards
+
+export const isCreateResource = (e: Extension): e is CreateResource =>
+  e.type === 'core.resource/create';
+
+// Arbitrary types
+
+/** Properties of custom CreateResource component. */
+export type CreateResourceComponentProps = { namespace?: string };

--- a/packages/lib-core/src/extensions/telemetry.ts
+++ b/packages/lib-core/src/extensions/telemetry.ts
@@ -1,0 +1,22 @@
+import type { AnyObject } from '@monorepo/common';
+import type { Extension, CodeRef } from '../types/extension';
+
+export type TelemetryListener = Extension<
+  'core.telemetry/listener',
+  {
+    /** Listen for telemetry events */
+    listener: CodeRef<TelemetryEventListener>;
+  }
+>;
+
+// TProperties should be valid JSON
+export type TelemetryEventListener = <TProperties = AnyObject>(
+  eventType: string,
+  properties?: TProperties,
+) => void;
+
+// Type guards
+
+export const isTelemetryListener = (e: Extension): e is TelemetryListener => {
+  return e.type === 'core.telemetry/listener';
+};

--- a/packages/lib-core/src/extensions/yaml-templates.ts
+++ b/packages/lib-core/src/extensions/yaml-templates.ts
@@ -1,0 +1,23 @@
+import type { ExtensionK8sResourceIdentifier } from '../types/common';
+import type { Extension, CodeRef } from '../types/extension';
+
+/** YAML templates for editing resources via the yaml editor. */
+export type YAMLTemplate = Extension<
+  'core.yaml-template',
+  {
+    /** Model associated with the template. */
+    model: ExtensionK8sResourceIdentifier & {
+      group: string;
+      version: string;
+      kind: string;
+    };
+    /** The YAML template. */
+    template: CodeRef<string>;
+    /** The name of the template. Use the name `default` to mark this as the default template. */
+    name: string | 'default';
+  }
+>;
+
+// Type guards
+
+export const isYAMLTemplate = (e: Extension): e is YAMLTemplate => e.type === 'core.yaml-template';

--- a/packages/lib-core/src/types/common.ts
+++ b/packages/lib-core/src/types/common.ts
@@ -1,0 +1,14 @@
+import type { AnyObject } from '@monorepo/common';
+
+// Type for extension hook
+export type ExtensionHook<TResult, TOptions extends AnyObject = AnyObject> = (
+  options: TOptions,
+) => [TResult, boolean, unknown];
+
+// TODO(vojtech): use types like RequiredProperties<T, K> and OptionalProperties<T, K>
+// to change optionality of specific properties, instead of redefining them via "&" intersection
+export type ExtensionK8sResourceIdentifier = {
+  group?: string;
+  version?: string;
+  kind?: string;
+};

--- a/packages/lib-core/src/types/core.ts
+++ b/packages/lib-core/src/types/core.ts
@@ -1,0 +1,9 @@
+export type K8sVerb =
+  | 'create'
+  | 'get'
+  | 'list'
+  | 'update'
+  | 'patch'
+  | 'delete'
+  | 'deletecollection'
+  | 'watch';

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,6 +69,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.9.2":
+  version: 7.17.2
+  resolution: "@babel/runtime@npm:7.17.2"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: a48702d271ecc59c09c397856407afa29ff980ab537b3da58eeee1aeaa0f545402d340a1680c9af58aec94dfdcbccfb6abb211991b74686a86d03d3f6956cacd
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^0.4.3":
   version: 0.4.3
   resolution: "@eslint/eslintrc@npm:0.4.3"
@@ -228,8 +237,10 @@ __metadata:
     "@rollup/plugin-typescript": ^8.3.0
     "@types/lodash-es": ^4.17.5
     "@types/react": ^17.0.37
+    "@types/react-router-dom": ^5.1.2
     lodash-es: ^4.17.21
     react: ^17.0.2
+    redux: ^4.1.2
     rollup: ^2.61.1
     rollup-plugin-analyzer: ^4.0.0
     rollup-plugin-dts: ^4.0.1
@@ -239,6 +250,7 @@ __metadata:
   peerDependencies:
     lodash-es: ^4.17.21
     react: ^17.0.2
+    redux: ^4.1.2
     yup: ^0.32.11
   languageName: unknown
   linkType: soft
@@ -300,6 +312,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/history@npm:^4.7.11":
+  version: 4.7.11
+  resolution: "@types/history@npm:4.7.11"
+  checksum: c92e2ba407dcab0581a9afdf98f533aa41b61a71133420a6d92b1ca9839f741ab1f9395b17454ba5b88cb86020b70b22d74a1950ccfbdfd9beeaa5459fdc3464
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.9":
   version: 7.0.9
   resolution: "@types/json-schema@npm:7.0.9"
@@ -348,6 +367,38 @@ __metadata:
   version: 15.7.4
   resolution: "@types/prop-types@npm:15.7.4"
   checksum: ef6e1899e59b876c273811b1bd845022fc66d5a3d11cb38a25b6c566b30514ae38fe20a40f67622f362a4f4f7f9224e22d8da101cff3d6e97e11d7b4c307cfc1
+  languageName: node
+  linkType: hard
+
+"@types/react-router-dom@npm:^5.1.2":
+  version: 5.3.3
+  resolution: "@types/react-router-dom@npm:5.3.3"
+  dependencies:
+    "@types/history": ^4.7.11
+    "@types/react": "*"
+    "@types/react-router": "*"
+  checksum: 28c4ea48909803c414bf5a08502acbb8ba414669b4b43bb51297c05fe5addc4df0b8fd00e0a9d1e3535ec4073ef38aaafac2c4a2b95b787167d113bc059beff3
+  languageName: node
+  linkType: hard
+
+"@types/react-router@npm:*":
+  version: 5.1.18
+  resolution: "@types/react-router@npm:5.1.18"
+  dependencies:
+    "@types/history": ^4.7.11
+    "@types/react": "*"
+  checksum: f08b37ee822f9f9ff904ffd0778fe2bb7c717ed3ee311610382ee024d02a35169bd3301ecde863cac21aae8fdee919501e8ea22bad0260c02c10cfbdba5c71be
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:*":
+  version: 17.0.39
+  resolution: "@types/react@npm:17.0.39"
+  dependencies:
+    "@types/prop-types": "*"
+    "@types/scheduler": "*"
+    csstype: ^3.0.2
+  checksum: bf04d3c2894559012710d595553e12b422d3b91cd8f4f7e122d8cb044ba9c2ba17f6e8a4e09581359cc5509ddc59cd8c8fabd6774f3505a40a45393f074d6e6e
   languageName: node
   linkType: hard
 
@@ -2725,6 +2776,15 @@ __metadata:
     string_decoder: ^1.1.1
     util-deprecate: ^1.0.1
   checksum: d4ea81502d3799439bb955a3a5d1d808592cf3133350ed352aeaa499647858b27b1c4013984900238b0873ec8d0d8defce72469fb7a83e61d53f5ad61cb80dc8
+  languageName: node
+  linkType: hard
+
+"redux@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "redux@npm:4.1.2"
+  dependencies:
+    "@babel/runtime": ^7.9.2
+  checksum: 6a839cee5bd580c5298d968e9e2302150e961318253819bcd97f9d945a5a409559eacddf6026f4118bb68b681c593d90e8a2c5bbf278f014aff9bf0d2d8fa084
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
JIRA: [HAC-424](https://issues.redhat.com/browse/HAC-424)

* [x] core.action/provider
* [x] core.action/resource-provider
* [x] core.action/group
* [x] core.action/filter
* [x] core.catalog/item-type
* [x] core.catalog/item-provider
* [x] core.catalog/item-filter
* [x] core.context-provider
* [x] core.flag
* [x] core.flag/model
* [x] core.navigation/href
* [x] core.navigation/resource-ns
* [x] core.navigation/separator
* [x] core.page/resource/list
* [x] core.page/resource/details
* [x] core.redux-reducer
* [x] core.resource/create
* [x] core.resource-metadata
 * this type doesn't exists in console, there's just `console.model-metadata` I've exported this extension type and also `core.resource-metadata`, they are both identical. We should consider deprecating one or the other.
* [x] core.telemetry/listener
* [x] core.yaml-template

Additional extensions:
* [x] core.page/route