### PR TITLE
Add lib-webpack package

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,64 @@
 ```
 npm install -g yarn
 ```
+
+## Distributable Packages
+
+Following packages are distributed via [npm registry](https://www.npmjs.com/):
+
+| Package Name | Description |
+| ------------ | ----------- |
+| `@openshift/dynamic-plugin-sdk` | Allows loading, managing and interpreting plugins. |
+| `@openshift/dynamic-plugin-sdk-utils` | Provides Kubernetes and React utilities. |
+| `@openshift/dynamic-plugin-sdk-webpack` | Allows building plugin assets with webpack. |
+
+Each package is versioned and published independently from other packages.
+
+## Publishing Packages
+
+### Update npm
+
+Make sure the `npm` package manager that comes with Node.js is up-to-date.
+
+To see the current installed version:
+
+```sh
+npm ls -g npm
+```
+
+To check if the current installed version is outdated:
+
+```sh
+npm outdated -g npm
+```
+
+To install the latest version:
+
+```sh
+npm install -g npm@<version>
+```
+
+### Log into npmjs account
+
+Only members of npmjs [openshift organization](https://www.npmjs.com/org/openshift) can publish
+packages maintained in this repo.
+
+```sh
+npm login
+```
+
+### Publish a package
+
+To publish the given package using the current version as specified in its `package.json`:
+
+```sh
+npm publish packages/lib-<pkg> --no-git-tag-version
+```
+
+To publish a package under a different version and update its `package.json` accordingly:
+
+```sh
+npm publish packages/lib-<pkg> --no-git-tag-version --new-version <version>
+```
+
+It's recommended to add `--dry-run` to `npm publish` command prior to actual publish.

--- a/packages/lib-core/src/constants.ts
+++ b/packages/lib-core/src/constants.ts
@@ -1,0 +1,3 @@
+export const PLUGIN_MANIFEST = 'plugin-manifest.json';
+export const REMOTE_ENTRY_SCRIPT = 'plugin-entry.js';
+export const REMOTE_ENTRY_CALLBACK = '__load_plugin_entry__';

--- a/packages/lib-core/src/index.ts
+++ b/packages/lib-core/src/index.ts
@@ -12,10 +12,10 @@ export { usePluginInfo } from './store/usePluginInfo';
 export { useResolvedExtensions } from './store/useResolvedExtensions';
 
 // Support APIs, to be consumed by other plugin SDK packages
-export { PluginRuntimeMetadata, PluginRuntimeManifest } from './types/plugin';
+export { PLUGIN_MANIFEST, REMOTE_ENTRY_SCRIPT, REMOTE_ENTRY_CALLBACK } from './constants';
+export { PluginRuntimeMetadata, PluginManifest } from './types/plugin';
 export {
   extensionArraySchema,
   pluginRuntimeMetadataSchema,
-  pluginRuntimeManifestSchema,
+  pluginManifestSchema,
 } from './yup-schemas';
-export { pluginManifestFile, remoteEntryScript, remoteEntryCallback } from './store/PluginLoader';

--- a/packages/lib-core/src/index.ts
+++ b/packages/lib-core/src/index.ts
@@ -1,3 +1,5 @@
+// Main APIs, to be consumed by plugins and host applications
+export { Extension } from './types/extension';
 export { PluginLoader, PluginLoaderOptions } from './store/PluginLoader';
 export { PluginStore, PluginStoreOptions } from './store/PluginStore';
 export {
@@ -8,3 +10,12 @@ export {
 export { useExtensions } from './store/useExtensions';
 export { usePluginInfo } from './store/usePluginInfo';
 export { useResolvedExtensions } from './store/useResolvedExtensions';
+
+// Support APIs, to be consumed by other plugin SDK packages
+export { PluginRuntimeMetadata, PluginRuntimeManifest } from './types/plugin';
+export {
+  extensionArraySchema,
+  pluginRuntimeMetadataSchema,
+  pluginRuntimeManifestSchema,
+} from './yup-schemas';
+export { pluginManifestFile, remoteEntryScript, remoteEntryCallback } from './store/PluginLoader';

--- a/packages/lib-core/src/store/PluginStore.ts
+++ b/packages/lib-core/src/store/PluginStore.ts
@@ -1,7 +1,7 @@
 import { consoleLogger } from '@monorepo/common';
 import * as _ from 'lodash-es';
 import type { Extension, LoadedExtension, CodeRef } from '../types/extension';
-import type { PluginRuntimeMetadata, PluginRuntimeManifest, LoadedPlugin } from '../types/plugin';
+import type { PluginRuntimeMetadata, PluginManifest, LoadedPlugin } from '../types/plugin';
 import type { PluginEntryModule } from '../types/runtime';
 import type { PluginInfoEntry, PluginConsumer, PluginManager } from '../types/store';
 import { PluginEventType } from '../types/store';
@@ -69,7 +69,7 @@ export class PluginStore implements PluginConsumer, PluginManager {
       }
 
       const pluginAdded = this.addPlugin(
-        _.omit<PluginRuntimeManifest, 'extensions'>(result.manifest, 'extensions'),
+        _.omit<PluginManifest, 'extensions'>(result.manifest, 'extensions'),
         this.processExtensions(pluginName, result.manifest.extensions, result.entryModule),
       );
 
@@ -159,7 +159,7 @@ export class PluginStore implements PluginConsumer, PluginManager {
       return;
     }
 
-    let manifest: PluginRuntimeManifest;
+    let manifest: PluginManifest;
 
     try {
       manifest = await this.loader.getPluginManifest(baseURL);

--- a/packages/lib-core/src/store/PluginStore.ts
+++ b/packages/lib-core/src/store/PluginStore.ts
@@ -1,7 +1,7 @@
 import { consoleLogger } from '@monorepo/common';
 import * as _ from 'lodash-es';
 import type { Extension, LoadedExtension, CodeRef } from '../types/extension';
-import type { PluginMetadata, PluginManifest, LoadedPlugin } from '../types/plugin';
+import type { PluginRuntimeMetadata, PluginRuntimeManifest, LoadedPlugin } from '../types/plugin';
 import type { PluginEntryModule } from '../types/runtime';
 import type { PluginInfoEntry, PluginConsumer, PluginManager } from '../types/store';
 import { PluginEventType } from '../types/store';
@@ -69,7 +69,7 @@ export class PluginStore implements PluginConsumer, PluginManager {
       }
 
       const pluginAdded = this.addPlugin(
-        _.omit<PluginManifest, 'extensions'>(result.manifest, 'extensions'),
+        _.omit<PluginRuntimeManifest, 'extensions'>(result.manifest, 'extensions'),
         this.processExtensions(pluginName, result.manifest.extensions, result.entryModule),
       );
 
@@ -159,7 +159,7 @@ export class PluginStore implements PluginConsumer, PluginManager {
       return;
     }
 
-    let manifest: PluginManifest;
+    let manifest: PluginRuntimeManifest;
 
     try {
       manifest = await this.loader.getPluginManifest(baseURL);
@@ -216,7 +216,7 @@ export class PluginStore implements PluginConsumer, PluginManager {
    *
    * Returns `true` if the plugin was added successfully.
    */
-  addPlugin(metadata: PluginMetadata, processedExtensions: LoadedExtension[]) {
+  addPlugin(metadata: PluginRuntimeMetadata, processedExtensions: LoadedExtension[]) {
     const pluginName = metadata.name;
     const pluginVersion = metadata.version;
 

--- a/packages/lib-core/src/types/extension.ts
+++ b/packages/lib-core/src/types/extension.ts
@@ -18,7 +18,7 @@ export type EncodedCodeRef = { $codeRef: string };
 
 export type CodeRef<TValue = unknown> = () => Promise<TValue>;
 
-// TODO(vojtech) apply the recursive part only on object properties or array elements
+// TODO(vojtech): apply the recursive part only on object properties or array elements
 type ExtractCodeRefValues<T> = {
   [K in keyof T]: T[K] extends CodeRef<infer TValue> ? TValue : ExtractCodeRefValues<T[K]>;
 };

--- a/packages/lib-core/src/types/plugin.ts
+++ b/packages/lib-core/src/types/plugin.ts
@@ -5,7 +5,7 @@ export type PluginRuntimeMetadata = {
   version: string;
 };
 
-export type PluginRuntimeManifest = PluginRuntimeMetadata & {
+export type PluginManifest = PluginRuntimeMetadata & {
   extensions: Extension[];
 };
 

--- a/packages/lib-core/src/types/plugin.ts
+++ b/packages/lib-core/src/types/plugin.ts
@@ -1,16 +1,16 @@
 import type { Extension, LoadedExtension } from './extension';
 
-export type PluginMetadata = {
+export type PluginRuntimeMetadata = {
   name: string;
   version: string;
 };
 
-export type PluginManifest = PluginMetadata & {
+export type PluginRuntimeManifest = PluginRuntimeMetadata & {
   extensions: Extension[];
 };
 
 export type LoadedPlugin = {
-  metadata: Readonly<PluginMetadata>;
+  metadata: Readonly<PluginRuntimeMetadata>;
   extensions: Readonly<LoadedExtension[]>;
   enabled: boolean;
 };

--- a/packages/lib-core/src/yup-schemas.ts
+++ b/packages/lib-core/src/yup-schemas.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup';
  *
  * @see https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
  */
-const semverString = yup
+const semverStringSchema = yup
   .string()
   .required()
   .matches(
@@ -14,29 +14,29 @@ const semverString = yup
   );
 
 /**
- * Schema for `PluginMetadata.name` property.
+ * Schema for a valid plugin name.
  *
- * Examples of valid plugin names:
+ * Examples:
  *
  * ```
  * foo, foo-bar, foo.bar, foo.bar-test, foo-bar-abc.123-test
  * ```
  */
-const pluginName = yup
+const pluginNameSchema = yup
   .string()
   .required()
   .matches(/^[a-z]+[a-z0-9-.]*[a-z]+$/, 'plugin name');
 
 /**
- * Schema for `Extension.type` property.
+ * Schema for a valid extension type.
  *
- * Examples of valid extension types:
+ * Examples:
  *
  * ```
  * app.foo, my-app.foo-bar, app.foo/bar, my-app.foo-bar/test/a-b
  * ```
  */
-const extensionType = yup
+const extensionTypeSchema = yup
   .string()
   .required()
   .matches(/^[a-z]+[a-z-]*\.[a-z]+[a-z-]*(?:\/[a-z]+[a-z-]*)*$/, 'extension type');
@@ -44,21 +44,27 @@ const extensionType = yup
 /**
  * Schema for `Extension` objects.
  */
-const extension = yup.object().required().shape({
-  type: extensionType,
+export const extensionSchema = yup.object().required().shape({
+  type: extensionTypeSchema,
   properties: yup.object().required(),
 });
 
 /**
- * Schema for `PluginManifest` objects.
+ * Schema for an array of extensions.
  */
-export const pluginManifest = yup
-  .object()
-  .required()
-  .shape({
-    name: pluginName,
-    version: semverString,
-    extensions: yup.array().of(extension).required(),
-  });
+export const extensionArraySchema = yup.array().of(extensionSchema).required();
 
-export { pluginManifest as pluginManifestSchema };
+/**
+ * Schema for `PluginRuntimeMetadata` objects.
+ */
+export const pluginRuntimeMetadataSchema = yup.object().required().shape({
+  name: pluginNameSchema,
+  version: semverStringSchema,
+});
+
+/**
+ * Schema for `PluginRuntimeManifest` objects.
+ */
+export const pluginRuntimeManifestSchema = pluginRuntimeMetadataSchema.shape({
+  extensions: extensionArraySchema,
+});

--- a/packages/lib-core/src/yup-schemas.ts
+++ b/packages/lib-core/src/yup-schemas.ts
@@ -63,8 +63,8 @@ export const pluginRuntimeMetadataSchema = yup.object().required().shape({
 });
 
 /**
- * Schema for `PluginRuntimeManifest` objects.
+ * Schema for `PluginManifest` objects.
  */
-export const pluginRuntimeManifestSchema = pluginRuntimeMetadataSchema.shape({
+export const pluginManifestSchema = pluginRuntimeMetadataSchema.shape({
   extensions: extensionArraySchema,
 });

--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -22,8 +22,10 @@
     "test": "echo 'Write some tests!'"
   },
   "peerDependencies": {
-    "lodash-es": "^4.17.21",
     "react": "^17.0.2"
+  },
+  "dependencies": {
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
     "@monorepo/common": "0.0.0-fixed",
@@ -31,7 +33,6 @@
     "@rollup/plugin-typescript": "^8.3.0",
     "@types/lodash-es": "^4.17.5",
     "@types/react": "^17.0.37",
-    "lodash-es": "^4.17.21",
     "react": "^17.0.2",
     "rollup": "^2.61.1",
     "rollup-plugin-analyzer": "^4.0.0",

--- a/packages/lib-webpack/.eslintrc.js
+++ b/packages/lib-webpack/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['plugin:@monorepo/eslint-plugin-internal/node-typescript-prettier'],
+};

--- a/packages/lib-webpack/package.json
+++ b/packages/lib-webpack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-webpack",
   "version": "1.0.0-alpha1",
-  "description": "Allows building plugins with webpack",
+  "description": "Allows building plugin assets with webpack",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/lib-webpack/package.json
+++ b/packages/lib-webpack/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@openshift/dynamic-plugin-sdk",
+  "name": "@openshift/dynamic-plugin-sdk-webpack",
   "version": "1.0.0-alpha1",
-  "description": "Allows loading, managing and interpreting plugins",
+  "description": "Allows building plugins with webpack",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/openshift/dynamic-plugin-sdk.git",
-    "directory": "packages/lib-core"
+    "directory": "packages/lib-webpack"
   },
   "files": [
     "dist/index.js",
@@ -18,30 +18,33 @@
     "prepack": "yarn build",
     "prepublish": "yarn test",
     "build": "rm -rf dist && rollup -c",
-    "lint": "yarn lint:run --ext .ts,.tsx src rollup.config.js",
+    "lint": "echo 'Run the linter!'",
     "test": "echo 'Write some tests!'"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "redux": "^4.1.2"
+    "@openshift/dynamic-plugin-sdk": "^1.0.0",
+    "webpack": "^5.69.1"
   },
   "dependencies": {
+    "glob": "^7.2.0",
     "lodash-es": "^4.17.21",
     "yup": "^0.32.11"
   },
   "devDependencies": {
     "@monorepo/common": "0.0.0-fixed",
+    "@openshift/dynamic-plugin-sdk": "link:../lib-core",
     "@rollup/plugin-node-resolve": "^13.1.1",
     "@rollup/plugin-typescript": "^8.3.0",
+    "@types/glob": "^7.2.0",
     "@types/lodash-es": "^4.17.5",
-    "@types/react": "^17.0.37",
-    "@types/react-router-dom": "^5.1.2",
-    "react": "^17.0.2",
-    "redux": "^4.1.2",
     "rollup": "^2.61.1",
     "rollup-plugin-analyzer": "^4.0.0",
     "rollup-plugin-dts": "^4.0.1",
     "tslib": "^2.3.1",
-    "typescript": "~4.4.4"
+    "typescript": "~4.4.4",
+    "webpack": "^5.69.1"
+  },
+  "engines": {
+    "node": ">=16"
   }
 }

--- a/packages/lib-webpack/rollup.config.js
+++ b/packages/lib-webpack/rollup.config.js
@@ -1,0 +1,11 @@
+// eslint-disable-next-line import/no-relative-packages
+import { tsLibConfig, dtsLibConfig } from '../common/rollup-configs';
+import pkg from './package.json';
+
+// eslint-disable-next-line no-console
+console.log(`Rollup ${pkg.name}`);
+
+export default [
+  tsLibConfig(pkg, 'src/index.ts'),
+  dtsLibConfig(pkg, 'dist/types/lib-webpack/src/index.d.ts'),
+];

--- a/packages/lib-webpack/src/index.ts
+++ b/packages/lib-webpack/src/index.ts
@@ -1,0 +1,1 @@
+export { DynamicRemotePlugin, DynamicRemotePluginOptions } from './webpack/DynamicRemotePlugin';

--- a/packages/lib-webpack/src/types/plugin.ts
+++ b/packages/lib-webpack/src/types/plugin.ts
@@ -1,0 +1,5 @@
+import type { PluginRuntimeMetadata } from '@openshift/dynamic-plugin-sdk';
+
+export type PluginBuildMetadata = PluginRuntimeMetadata & {
+  exposedModules?: { [moduleName: string]: string };
+};

--- a/packages/lib-webpack/src/utils/json.ts
+++ b/packages/lib-webpack/src/utils/json.ts
@@ -1,0 +1,4 @@
+import * as fs from 'fs';
+
+export const parseJSONFile = <TValue = unknown>(filePath: string) =>
+  JSON.parse(fs.readFileSync(filePath, 'utf-8')) as TValue;

--- a/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
+++ b/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
@@ -1,0 +1,167 @@
+import {
+  extensionArraySchema,
+  remoteEntryScript,
+  remoteEntryCallback,
+} from '@openshift/dynamic-plugin-sdk';
+import type { Extension } from '@openshift/dynamic-plugin-sdk';
+import * as _ from 'lodash-es';
+import * as fs from 'fs';
+import * as glob from 'glob';
+import * as path from 'path';
+import * as webpack from 'webpack';
+import type { PluginBuildMetadata } from '../types/plugin';
+import { pluginBuildMetadataSchema } from '../yup-schemas';
+import { GenerateManifestPlugin } from './GenerateManifestPlugin';
+import { PatchContainerEntryPlugin } from './PatchContainerEntryPlugin';
+
+const parseJSONFile = (filePath: string) => JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+
+const loadPluginMetadata = (fileName: string, baseDir = process.cwd()) => {
+  const filePath = path.resolve(baseDir, fileName);
+  return validatePluginMetadata(parseJSONFile(filePath));
+};
+
+const loadExtensions = (globPattern: string, baseDir = process.cwd()) => {
+  const filePaths = glob.sync(globPattern, { cwd: baseDir, absolute: true, nodir: true });
+  return _.flatMap(filePaths.map((filePath) => validateExtensions(parseJSONFile(filePath))));
+};
+
+const validatePluginMetadata = (obj: unknown): PluginBuildMetadata =>
+  pluginBuildMetadataSchema.strict(true).validateSync(obj);
+
+const validateExtensions = (obj: unknown): Extension[] =>
+  extensionArraySchema.strict(true).validateSync(obj);
+
+const getSharedModulesWithStrictSingletonConfig = (modules: string[]) =>
+  modules.reduce((acc, moduleRequest) => {
+    acc[moduleRequest] = {
+      // Enforce a single version of the shared module to be used at runtime
+      singleton: true,
+      // Prevent plugins from using a fallback version of the shared module
+      import: false,
+    };
+    return acc;
+  }, {} as WebpackSharedModules);
+
+/**
+ * Minimal subset of webpack `SharedConfig` type.
+ *
+ * @see https://webpack.js.org/plugins/module-federation-plugin/#sharing-hints
+ */
+type WebpackSharedModuleConfig = {
+  import?: string | false;
+  singleton?: boolean;
+};
+
+/**
+ * Equivalent to webpack `SharedObject` type.
+ */
+type WebpackSharedModules = { [moduleRequest: string]: WebpackSharedModuleConfig };
+
+export type DynamicRemotePluginOptions = Partial<{
+  /**
+   * Plugin metadata JSON file name, or the parsed plugin metadata.
+   *
+   * Default value: `plugin.json`.
+   */
+  pluginMetadata: string | PluginBuildMetadata;
+
+  /**
+   * List of extensions contributed by the plugin.
+   *
+   * The value is either a `minimatch` compatible JSON file glob pattern,
+   * or the parsed extensions array.
+   *
+   * Default value: `extensions.json`.
+   */
+  extensions: string | Extension[];
+
+  /**
+   * Modules shared between the host application and its plugins at runtime.
+   *
+   * Essential modules like `react` and `redux` will be added automatically.
+   *
+   * Default value: empty object.
+   */
+  sharedModules: WebpackSharedModules;
+}>;
+
+export class DynamicRemotePlugin implements webpack.WebpackPluginInstance {
+  private readonly pluginMetadata: PluginBuildMetadata;
+
+  private readonly extensions: Extension[];
+
+  private readonly sharedModules: WebpackSharedModules;
+
+  constructor(options: DynamicRemotePluginOptions = {}) {
+    const adaptedOptions: Required<DynamicRemotePluginOptions> = {
+      pluginMetadata: options.pluginMetadata ?? 'plugin.json',
+      extensions: options.extensions ?? 'extensions.json',
+      sharedModules: options.sharedModules ?? {},
+    };
+
+    // Load and validate plugin metadata
+    if (typeof adaptedOptions.pluginMetadata === 'string') {
+      this.pluginMetadata = loadPluginMetadata(adaptedOptions.pluginMetadata);
+    } else {
+      this.pluginMetadata = validatePluginMetadata(adaptedOptions.pluginMetadata);
+    }
+
+    // Load and validate extensions contributed by the plugin
+    if (typeof adaptedOptions.extensions === 'string') {
+      this.extensions = loadExtensions(adaptedOptions.extensions);
+    } else {
+      this.extensions = validateExtensions(adaptedOptions.extensions);
+    }
+
+    // Create plugin vs. host application shared module configuration
+    this.sharedModules = {
+      ...adaptedOptions.sharedModules,
+      ...getSharedModulesWithStrictSingletonConfig(['react', 'redux']),
+    };
+  }
+
+  apply(compiler: webpack.Compiler) {
+    const logger = compiler.getInfrastructureLogger(DynamicRemotePlugin.name);
+    const containerName = this.pluginMetadata.name;
+
+    if (!compiler.options.output.publicPath) {
+      logger.warn(
+        'output.publicPath is not defined, which may cause plugin assets to not load properly in the browser',
+      );
+    }
+
+    if (!compiler.options.output.uniqueName) {
+      logger.info(`output.uniqueName will be set to ${containerName}`);
+      compiler.options.output.uniqueName = containerName;
+    }
+
+    // Generate webpack federated module container assets
+    new webpack.container.ModuleFederationPlugin({
+      name: containerName,
+      library: {
+        type: 'jsonp',
+        name: remoteEntryCallback,
+      },
+      filename: remoteEntryScript,
+      exposes: _.mapValues(
+        this.pluginMetadata.exposedModules || {},
+        (moduleRequest, moduleName) => ({
+          import: moduleRequest,
+          name: `exposed-${moduleName}`,
+        }),
+      ),
+      shared: this.sharedModules,
+    }).apply(compiler);
+
+    // Generate plugin manifest
+    new GenerateManifestPlugin({
+      name: this.pluginMetadata.name,
+      version: this.pluginMetadata.version,
+      extensions: this.extensions,
+    }).apply(compiler);
+
+    // Post-process container entry generated by ModuleFederationPlugin
+    new PatchContainerEntryPlugin(this.pluginMetadata.name).apply(compiler);
+  }
+}

--- a/packages/lib-webpack/src/webpack/GenerateManifestPlugin.ts
+++ b/packages/lib-webpack/src/webpack/GenerateManifestPlugin.ts
@@ -1,9 +1,9 @@
-import { pluginManifestFile } from '@openshift/dynamic-plugin-sdk';
-import type { PluginRuntimeManifest } from '@openshift/dynamic-plugin-sdk';
+import { PLUGIN_MANIFEST } from '@openshift/dynamic-plugin-sdk';
+import type { PluginManifest } from '@openshift/dynamic-plugin-sdk';
 import * as webpack from 'webpack';
 
 export class GenerateManifestPlugin implements webpack.WebpackPluginInstance {
-  constructor(private readonly manifest: PluginRuntimeManifest) {}
+  constructor(private readonly manifest: PluginManifest) {}
 
   apply(compiler: webpack.Compiler) {
     compiler.hooks.thisCompilation.tap(GenerateManifestPlugin.name, (compilation) => {
@@ -14,7 +14,7 @@ export class GenerateManifestPlugin implements webpack.WebpackPluginInstance {
         },
         () => {
           compilation.emitAsset(
-            pluginManifestFile,
+            PLUGIN_MANIFEST,
             new webpack.sources.RawSource(Buffer.from(JSON.stringify(this.manifest, null, 2))),
           );
         },

--- a/packages/lib-webpack/src/webpack/GenerateManifestPlugin.ts
+++ b/packages/lib-webpack/src/webpack/GenerateManifestPlugin.ts
@@ -1,0 +1,24 @@
+import { pluginManifestFile } from '@openshift/dynamic-plugin-sdk';
+import type { PluginRuntimeManifest } from '@openshift/dynamic-plugin-sdk';
+import * as webpack from 'webpack';
+
+export class GenerateManifestPlugin implements webpack.WebpackPluginInstance {
+  constructor(private readonly manifest: PluginRuntimeManifest) {}
+
+  apply(compiler: webpack.Compiler) {
+    compiler.hooks.thisCompilation.tap(GenerateManifestPlugin.name, (compilation) => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: GenerateManifestPlugin.name,
+          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+        },
+        () => {
+          compilation.emitAsset(
+            pluginManifestFile,
+            new webpack.sources.RawSource(Buffer.from(JSON.stringify(this.manifest, null, 2))),
+          );
+        },
+      );
+    });
+  }
+}

--- a/packages/lib-webpack/src/webpack/PatchContainerEntryPlugin.ts
+++ b/packages/lib-webpack/src/webpack/PatchContainerEntryPlugin.ts
@@ -1,4 +1,4 @@
-import { remoteEntryScript, remoteEntryCallback } from '@openshift/dynamic-plugin-sdk';
+import { REMOTE_ENTRY_SCRIPT, REMOTE_ENTRY_CALLBACK } from '@openshift/dynamic-plugin-sdk';
 import * as webpack from 'webpack';
 
 export class PatchContainerEntryPlugin implements webpack.WebpackPluginInstance {
@@ -12,20 +12,20 @@ export class PatchContainerEntryPlugin implements webpack.WebpackPluginInstance 
           stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
         },
         () => {
-          compilation.updateAsset(remoteEntryScript, (source) => {
+          compilation.updateAsset(REMOTE_ENTRY_SCRIPT, (source) => {
             const newSource = new webpack.sources.ReplaceSource(source);
-            const fromIndex = source.source().toString().indexOf(`${remoteEntryCallback}(`);
+            const fromIndex = source.source().toString().indexOf(`${REMOTE_ENTRY_CALLBACK}(`);
 
             if (fromIndex >= 0) {
               newSource.insert(
-                fromIndex + remoteEntryCallback.length + 1,
+                fromIndex + REMOTE_ENTRY_CALLBACK.length + 1,
                 `'${this.pluginName}', `,
               );
             } else {
               const error = new webpack.WebpackError(
-                `Missing call to ${remoteEntryCallback} in ${remoteEntryScript}`,
+                `Missing call to ${REMOTE_ENTRY_CALLBACK} in ${REMOTE_ENTRY_SCRIPT}`,
               );
-              error.file = remoteEntryScript;
+              error.file = REMOTE_ENTRY_SCRIPT;
               compilation.errors.push(error);
             }
 

--- a/packages/lib-webpack/src/webpack/PatchContainerEntryPlugin.ts
+++ b/packages/lib-webpack/src/webpack/PatchContainerEntryPlugin.ts
@@ -1,0 +1,38 @@
+import { remoteEntryScript, remoteEntryCallback } from '@openshift/dynamic-plugin-sdk';
+import * as webpack from 'webpack';
+
+export class PatchContainerEntryPlugin implements webpack.WebpackPluginInstance {
+  constructor(private readonly pluginName: string) {}
+
+  apply(compiler: webpack.Compiler) {
+    compiler.hooks.thisCompilation.tap(PatchContainerEntryPlugin.name, (compilation) => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: PatchContainerEntryPlugin.name,
+          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+        },
+        () => {
+          compilation.updateAsset(remoteEntryScript, (source) => {
+            const newSource = new webpack.sources.ReplaceSource(source);
+            const fromIndex = source.source().toString().indexOf(`${remoteEntryCallback}(`);
+
+            if (fromIndex >= 0) {
+              newSource.insert(
+                fromIndex + remoteEntryCallback.length + 1,
+                `'${this.pluginName}', `,
+              );
+            } else {
+              const error = new webpack.WebpackError(
+                `Missing call to ${remoteEntryCallback} in ${remoteEntryScript}`,
+              );
+              error.file = remoteEntryScript;
+              compilation.errors.push(error);
+            }
+
+            return newSource;
+          });
+        },
+      );
+    });
+  }
+}

--- a/packages/lib-webpack/src/yup-schemas.ts
+++ b/packages/lib-webpack/src/yup-schemas.ts
@@ -1,0 +1,12 @@
+import * as yup from 'yup';
+import { pluginRuntimeMetadataSchema } from '@openshift/dynamic-plugin-sdk';
+
+/**
+ * Schema for `PluginBuildMetadata` objects.
+ */
+export const pluginBuildMetadataSchema = pluginRuntimeMetadataSchema.shape({
+  // TODO(vojtech): Here we'd like to validate `{ [moduleName: string]: string }`.
+  // Unfortunately, Yup doesn't support map-like structures natively and workarounds
+  // are ugly; we might need to switch to a different JS object validation library.
+  exposedModules: yup.object(),
+});

--- a/packages/lib-webpack/tsconfig.json
+++ b/packages/lib-webpack/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@monorepo/common/tsconfig-bases/node-cjs.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declarationDir": "types"
+  },
+  "include": ["src", "../common/src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,9 +223,39 @@ __metadata:
     tslib: ^2.3.1
     typescript: ~4.4.4
   peerDependencies:
-    lodash-es: ^4.17.21
     react: ^17.0.2
   languageName: unknown
+  linkType: soft
+
+"@openshift/dynamic-plugin-sdk-webpack@workspace:packages/lib-webpack":
+  version: 0.0.0-use.local
+  resolution: "@openshift/dynamic-plugin-sdk-webpack@workspace:packages/lib-webpack"
+  dependencies:
+    "@monorepo/common": 0.0.0-fixed
+    "@openshift/dynamic-plugin-sdk": "link:../lib-core"
+    "@rollup/plugin-node-resolve": ^13.1.1
+    "@rollup/plugin-typescript": ^8.3.0
+    "@types/glob": ^7.2.0
+    "@types/lodash-es": ^4.17.5
+    glob: ^7.2.0
+    lodash-es: ^4.17.21
+    rollup: ^2.61.1
+    rollup-plugin-analyzer: ^4.0.0
+    rollup-plugin-dts: ^4.0.1
+    tslib: ^2.3.1
+    typescript: ~4.4.4
+    webpack: ^5.69.1
+    yup: ^0.32.11
+  peerDependencies:
+    "@openshift/dynamic-plugin-sdk": ^1.0.0
+    webpack: ^5.69.1
+  languageName: unknown
+  linkType: soft
+
+"@openshift/dynamic-plugin-sdk@link:../lib-core::locator=%40openshift%2Fdynamic-plugin-sdk-webpack%40workspace%3Apackages%2Flib-webpack":
+  version: 0.0.0-use.local
+  resolution: "@openshift/dynamic-plugin-sdk@link:../lib-core::locator=%40openshift%2Fdynamic-plugin-sdk-webpack%40workspace%3Apackages%2Flib-webpack"
+  languageName: node
   linkType: soft
 
 "@openshift/dynamic-plugin-sdk@workspace:packages/lib-core":
@@ -248,10 +278,8 @@ __metadata:
     typescript: ~4.4.4
     yup: ^0.32.11
   peerDependencies:
-    lodash-es: ^4.17.21
     react: ^17.0.2
     redux: ^4.1.2
-    yup: ^0.32.11
   languageName: unknown
   linkType: soft
 
@@ -305,10 +333,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/eslint-scope@npm:^3.7.3":
+  version: 3.7.3
+  resolution: "@types/eslint-scope@npm:3.7.3"
+  dependencies:
+    "@types/eslint": "*"
+    "@types/estree": "*"
+  checksum: 6772b05e1b92003d1f295e81bc847a61f4fbe8ddab77ffa49e84ed3f9552513bdde677eb53ef167753901282857dd1d604d9f82eddb34a233495932b2dc3dc17
+  languageName: node
+  linkType: hard
+
+"@types/eslint@npm:*":
+  version: 8.4.1
+  resolution: "@types/eslint@npm:8.4.1"
+  dependencies:
+    "@types/estree": "*"
+    "@types/json-schema": "*"
+  checksum: b5790997ee9d3820d16350192d41849b0e2448c9e93650acac672ddf502e35c0a5a25547172a9eec840a96687cd94ba1cee672cbd86640f8f4ff1b65960d2ab9
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:*, @types/estree@npm:^0.0.51":
+  version: 0.0.51
+  resolution: "@types/estree@npm:0.0.51"
+  checksum: e56a3bcf759fd9185e992e7fdb3c6a5f81e8ff120e871641607581fb3728d16c811702a7d40fa5f869b7f7b4437ab6a87eb8d98ffafeee51e85bbe955932a189
+  languageName: node
+  linkType: hard
+
 "@types/estree@npm:0.0.39":
   version: 0.0.39
   resolution: "@types/estree@npm:0.0.39"
   checksum: 412fb5b9868f2c418126451821833414189b75cc6bf84361156feed733e3d92ec220b9d74a89e52722e03d5e241b2932732711b7497374a404fad49087adc248
+  languageName: node
+  linkType: hard
+
+"@types/glob@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@types/glob@npm:7.2.0"
+  dependencies:
+    "@types/minimatch": "*"
+    "@types/node": "*"
+  checksum: 6ae717fedfdfdad25f3d5a568323926c64f52ef35897bcac8aca8e19bc50c0bd84630bbd063e5d52078b2137d8e7d3c26eabebd1a2f03ff350fff8a91e79fc19
   languageName: node
   linkType: hard
 
@@ -319,7 +384,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.9
   resolution: "@types/json-schema@npm:7.0.9"
   checksum: 259d0e25f11a21ba5c708f7ea47196bd396e379fddb79c76f9f4f62c945879dc21657904914313ec2754e443c5018ea8372362f323f30e0792897fdb2098a705
@@ -353,6 +418,13 @@ __metadata:
   version: 4.14.178
   resolution: "@types/lodash@npm:4.14.178"
   checksum: a69a04a60bfc5257c3130a554b4efa0c383f0141b7b3db8ab7cf07ad2a46ea085fce66d0242da41da7e5647b133d5dfb2c15add9cbed8d7fef955e4a1e5b3128
+  languageName: node
+  linkType: hard
+
+"@types/minimatch@npm:*":
+  version: 3.0.5
+  resolution: "@types/minimatch@npm:3.0.5"
+  checksum: c41d136f67231c3131cf1d4ca0b06687f4a322918a3a5adddc87ce90ed9dbd175a3610adee36b106ae68c0b92c637c35e02b58c8a56c424f71d30993ea220b92
   languageName: node
   linkType: hard
 
@@ -529,10 +601,184 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/ast@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/ast@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/helper-numbers": 1.11.1
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.1
+  checksum: 1eee1534adebeece635362f8e834ae03e389281972611408d64be7895fc49f48f98fddbbb5339bf8a72cb101bcb066e8bca3ca1bf1ef47dadf89def0395a8d87
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/floating-point-hex-parser@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/floating-point-hex-parser@npm:1.11.1"
+  checksum: b8efc6fa08e4787b7f8e682182d84dfdf8da9d9c77cae5d293818bc4a55c1f419a87fa265ab85252b3e6c1fd323d799efea68d825d341a7c365c64bc14750e97
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-api-error@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-api-error@npm:1.11.1"
+  checksum: 0792813f0ed4a0e5ee0750e8b5d0c631f08e927f4bdfdd9fe9105dc410c786850b8c61bff7f9f515fdfb149903bec3c976a1310573a4c6866a94d49bc7271959
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-buffer@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-buffer@npm:1.11.1"
+  checksum: a337ee44b45590c3a30db5a8b7b68a717526cf967ada9f10253995294dbd70a58b2da2165222e0b9830cd4fc6e4c833bf441a721128d1fe2e9a7ab26b36003ce
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-numbers@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-numbers@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser": 1.11.1
+    "@webassemblyjs/helper-api-error": 1.11.1
+    "@xtuc/long": 4.2.2
+  checksum: 44d2905dac2f14d1e9b5765cf1063a0fa3d57295c6d8930f6c59a36462afecc6e763e8a110b97b342a0f13376166c5d41aa928e6ced92e2f06b071fd0db59d3a
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-wasm-bytecode@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-wasm-bytecode@npm:1.11.1"
+  checksum: eac400113127832c88f5826bcc3ad1c0db9b3dbd4c51a723cfdb16af6bfcbceb608170fdaac0ab7731a7e18b291be7af68a47fcdb41cfe0260c10857e7413d97
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-wasm-section@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-wasm-section@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/helper-buffer": 1.11.1
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.1
+    "@webassemblyjs/wasm-gen": 1.11.1
+  checksum: 617696cfe8ecaf0532763162aaf748eb69096fb27950219bb87686c6b2e66e11cd0614d95d319d0ab1904bc14ebe4e29068b12c3e7c5e020281379741fe4bedf
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/ieee754@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/ieee754@npm:1.11.1"
+  dependencies:
+    "@xtuc/ieee754": ^1.2.0
+  checksum: 23a0ac02a50f244471631802798a816524df17e56b1ef929f0c73e3cde70eaf105a24130105c60aff9d64a24ce3b640dad443d6f86e5967f922943a7115022ec
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/leb128@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/leb128@npm:1.11.1"
+  dependencies:
+    "@xtuc/long": 4.2.2
+  checksum: 33ccc4ade2f24de07bf31690844d0b1ad224304ee2062b0e464a610b0209c79e0b3009ac190efe0e6bd568b0d1578d7c3047fc1f9d0197c92fc061f56224ff4a
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/utf8@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/utf8@npm:1.11.1"
+  checksum: 972c5cfc769d7af79313a6bfb96517253a270a4bf0c33ba486aa43cac43917184fb35e51dfc9e6b5601548cd5931479a42e42c89a13bb591ffabebf30c8a6a0b
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wasm-edit@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wasm-edit@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/helper-buffer": 1.11.1
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.1
+    "@webassemblyjs/helper-wasm-section": 1.11.1
+    "@webassemblyjs/wasm-gen": 1.11.1
+    "@webassemblyjs/wasm-opt": 1.11.1
+    "@webassemblyjs/wasm-parser": 1.11.1
+    "@webassemblyjs/wast-printer": 1.11.1
+  checksum: 6d7d9efaec1227e7ef7585a5d7ff0be5f329f7c1c6b6c0e906b18ed2e9a28792a5635e450aca2d136770d0207225f204eff70a4b8fd879d3ac79e1dcc26dbeb9
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wasm-gen@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wasm-gen@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.1
+    "@webassemblyjs/ieee754": 1.11.1
+    "@webassemblyjs/leb128": 1.11.1
+    "@webassemblyjs/utf8": 1.11.1
+  checksum: 1f6921e640293bf99fb16b21e09acb59b340a79f986c8f979853a0ae9f0b58557534b81e02ea2b4ef11e929d946708533fd0693c7f3712924128fdafd6465f5b
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wasm-opt@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wasm-opt@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/helper-buffer": 1.11.1
+    "@webassemblyjs/wasm-gen": 1.11.1
+    "@webassemblyjs/wasm-parser": 1.11.1
+  checksum: 21586883a20009e2b20feb67bdc451bbc6942252e038aae4c3a08e6f67b6bae0f5f88f20bfc7bd0452db5000bacaf5ab42b98cf9aa034a6c70e9fc616142e1db
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wasm-parser@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wasm-parser@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/helper-api-error": 1.11.1
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.1
+    "@webassemblyjs/ieee754": 1.11.1
+    "@webassemblyjs/leb128": 1.11.1
+    "@webassemblyjs/utf8": 1.11.1
+  checksum: 1521644065c360e7b27fad9f4bb2df1802d134dd62937fa1f601a1975cde56bc31a57b6e26408b9ee0228626ff3ba1131ae6f74ffb7d718415b6528c5a6dbfc2
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wast-printer@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wast-printer@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/ast": 1.11.1
+    "@xtuc/long": 4.2.2
+  checksum: f15ae4c2441b979a3b4fce78f3d83472fb22350c6dc3fd34bfe7c3da108e0b2360718734d961bba20e7716cb8578e964b870da55b035e209e50ec9db0378a3f7
+  languageName: node
+  linkType: hard
+
+"@xtuc/ieee754@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@xtuc/ieee754@npm:1.2.0"
+  checksum: ac56d4ca6e17790f1b1677f978c0c6808b1900a5b138885d3da21732f62e30e8f0d9120fcf8f6edfff5100ca902b46f8dd7c1e3f903728634523981e80e2885a
+  languageName: node
+  linkType: hard
+
+"@xtuc/long@npm:4.2.2":
+  version: 4.2.2
+  resolution: "@xtuc/long@npm:4.2.2"
+  checksum: 8ed0d477ce3bc9c6fe2bf6a6a2cc316bb9c4127c5a7827bae947fa8ec34c7092395c5a283cc300c05b5fa01cbbfa1f938f410a7bf75db7c7846fea41949989ec
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:1":
   version: 1.1.1
   resolution: "abbrev@npm:1.1.1"
   checksum: a4a97ec07d7ea112c517036882b2ac22f3109b7b19077dc656316d07d308438aac28e4d9746dc4d84bf6b1e75b4a7b0a5f3cb30592419f128ca9a8cee3bcfa17
+  languageName: node
+  linkType: hard
+
+"acorn-import-assertions@npm:^1.7.6":
+  version: 1.8.0
+  resolution: "acorn-import-assertions@npm:1.8.0"
+  peerDependencies:
+    acorn: ^8
+  checksum: 5c4cf7c850102ba7ae0eeae0deb40fb3158c8ca5ff15c0bca43b5c47e307a1de3d8ef761788f881343680ea374631ae9e9615ba8876fee5268dbe068c98bcba6
   languageName: node
   linkType: hard
 
@@ -551,6 +797,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 1860f23c2107c910c6177b7b7be71be350db9e1080d814493fae143ae37605189504152d1ba8743ba3178d0b37269ce1ffc42b101547fdc1827078f82671e407
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.4.1, acorn@npm:^8.5.0":
+  version: 8.7.0
+  resolution: "acorn@npm:8.7.0"
+  bin:
+    acorn: bin/acorn
+  checksum: e0f79409d68923fbf1aa6d4166f3eedc47955320d25c89a20cc822e6ba7c48c5963d5bc657bc242d68f7a4ac9faf96eef033e8f73656da6c640d4219935fdfd0
   languageName: node
   linkType: hard
 
@@ -584,7 +839,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.10.0, ajv@npm:^6.12.4":
+"ajv-keywords@npm:^3.5.2":
+  version: 3.5.2
+  resolution: "ajv-keywords@npm:3.5.2"
+  peerDependencies:
+    ajv: ^6.9.1
+  checksum: 7dc5e5931677a680589050f79dcbe1fefbb8fea38a955af03724229139175b433c63c68f7ae5f86cf8f65d55eb7c25f75a046723e2e58296707617ca690feae9
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^6.10.0, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -772,6 +1036,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist@npm:^4.14.5":
+  version: 4.19.3
+  resolution: "browserslist@npm:4.19.3"
+  dependencies:
+    caniuse-lite: ^1.0.30001312
+    electron-to-chromium: ^1.4.71
+    escalade: ^3.1.1
+    node-releases: ^2.0.2
+    picocolors: ^1.0.0
+  bin:
+    browserslist: cli.js
+  checksum: c28958313dd17f345dd6e26379cc863126cd7d855588e57a1ed9e552a1135d64f05ec57063b48fff0d94a9b785bd248e9472c2d63ce8460ca56fc2444f5a1e66
+  languageName: node
+  linkType: hard
+
+"buffer-from@npm:^1.0.0":
+  version: 1.1.2
+  resolution: "buffer-from@npm:1.1.2"
+  checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
+  languageName: node
+  linkType: hard
+
 "builtin-modules@npm:^3.1.0":
   version: 3.2.0
   resolution: "builtin-modules@npm:3.2.0"
@@ -822,6 +1108,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"caniuse-lite@npm:^1.0.30001312":
+  version: 1.0.30001312
+  resolution: "caniuse-lite@npm:1.0.30001312"
+  checksum: 753fb9ea1e02e999430b323a71b5acab5120f3b5fc0161b01669f54a3ef5c5296240b6ae9b79b12a3742e3aed216aa9ee3d5398a23c16d08625ccd376b79545d
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^2.0.0":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -847,6 +1140,13 @@ __metadata:
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
   checksum: c57cf9dd0791e2f18a5ee9c1a299ae6e801ff58fee96dc8bfd0dcb4738a6ce58dd252a3605b1c93c6418fe4f9d5093b28ffbf4d66648cb2a9c67eaef9679be2f
+  languageName: node
+  linkType: hard
+
+"chrome-trace-event@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "chrome-trace-event@npm:1.0.3"
+  checksum: cb8b1fc7e881aaef973bd0c4a43cd353c2ad8323fb471a041e64f7c2dd849cde4aad15f8b753331a32dda45c973f032c8a03b8177fc85d60eaa75e91e08bfb97
   languageName: node
   linkType: hard
 
@@ -895,6 +1195,13 @@ __metadata:
   bin:
     color-support: bin.js
   checksum: 9b7356817670b9a13a26ca5af1c21615463b500783b739b7634a0c2047c16cef4b2865d7576875c31c3cddf9dd621fa19285e628f20198b233a5cfdda6d0793b
+  languageName: node
+  linkType: hard
+
+"commander@npm:^2.20.0":
+  version: 2.20.3
+  resolution: "commander@npm:2.20.3"
+  checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
   languageName: node
   linkType: hard
 
@@ -1057,6 +1364,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"electron-to-chromium@npm:^1.4.71":
+  version: 1.4.71
+  resolution: "electron-to-chromium@npm:1.4.71"
+  checksum: ecb2546eed6b0e95003d787c259de730f32e2f5c0fa2acb27069c0cd21378cbc2a6c7516f4ec677a5960db4e180644f87ed91a729825a238454e31e4e74617db
+  languageName: node
+  linkType: hard
+
 "emoji-regex@npm:^8.0.0":
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
@@ -1077,6 +1391,16 @@ __metadata:
   dependencies:
     iconv-lite: ^0.6.2
   checksum: bb98632f8ffa823996e508ce6a58ffcf5856330fde839ae42c9e1f436cc3b5cc651d4aeae72222916545428e54fd0f6aa8862fd8d25bdbcc4589f1e3f3715e7f
+  languageName: node
+  linkType: hard
+
+"enhanced-resolve@npm:^5.8.3":
+  version: 5.9.0
+  resolution: "enhanced-resolve@npm:5.9.0"
+  dependencies:
+    graceful-fs: ^4.2.4
+    tapable: ^2.2.0
+  checksum: 06435f52670229eb7fd8d92ea2d988a275f9a1b8c08b9023ba45767c6ed844bc87aa9c9c7e6d044eef99ad73fc3b066b78101163696e5c53121909e5bf8efe8b
   languageName: node
   linkType: hard
 
@@ -1131,6 +1455,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^0.9.0":
+  version: 0.9.3
+  resolution: "es-module-lexer@npm:0.9.3"
+  checksum: 84bbab23c396281db2c906c766af58b1ae2a1a2599844a504df10b9e8dc77ec800b3211fdaa133ff700f5703d791198807bba25d9667392d27a5e9feda344da8
+  languageName: node
+  linkType: hard
+
 "es-to-primitive@npm:^1.2.1":
   version: 1.2.1
   resolution: "es-to-primitive@npm:1.2.1"
@@ -1139,6 +1470,13 @@ __metadata:
     is-date-object: ^1.0.1
     is-symbol: ^1.0.2
   checksum: 4ead6671a2c1402619bdd77f3503991232ca15e17e46222b0a41a5d81aebc8740a77822f5b3c965008e631153e9ef0580540007744521e72de8e33599fca2eed
+  languageName: node
+  linkType: hard
+
+"escalade@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "escalade@npm:3.1.1"
+  checksum: a3e2a99f07acb74b3ad4989c48ca0c3140f69f923e56d0cba0526240ee470b91010f9d39001f2a4a313841d237ede70a729e92125191ba5d21e74b106800b133
   languageName: node
   linkType: hard
 
@@ -1366,7 +1704,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^5.1.1":
+"eslint-scope@npm:5.1.1, eslint-scope@npm:^5.1.1":
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
   dependencies:
@@ -1531,6 +1869,13 @@ __metadata:
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
   checksum: 22b5b08f74737379a840b8ed2036a5fb35826c709ab000683b092d9054e5c2a82c27818f12604bfc2a9a76b90b6834ef081edbc1c7ae30d1627012e067c6ec87
+  languageName: node
+  linkType: hard
+
+"events@npm:^3.2.0":
+  version: 3.3.0
+  resolution: "events@npm:3.3.0"
+  checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
   languageName: node
   linkType: hard
 
@@ -1724,7 +2069,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.7":
+"glob-to-regexp@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "glob-to-regexp@npm:0.4.1"
+  checksum: e795f4e8f06d2a15e86f76e4d92751cf8bbfcf0157cea5c2f0f35678a8195a750b34096b1256e436f0cebc1883b5ff0888c47348443e69546a5a87f9e1eb1167
+  languageName: node
+  linkType: hard
+
+"glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.7, glob@npm:^7.2.0":
   version: 7.2.0
   resolution: "glob@npm:7.2.0"
   dependencies:
@@ -1758,6 +2110,13 @@ __metadata:
     merge2: ^1.3.0
     slash: ^3.0.0
   checksum: d3e02d5e459e02ffa578b45f040381c33e3c0538ed99b958f0809230c423337999867d7b0dbf752ce93c46157d3bbf154d3fff988a93ccaeb627df8e1841775b
+  languageName: node
+  linkType: hard
+
+"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.9":
+  version: 4.2.9
+  resolution: "graceful-fs@npm:4.2.9"
+  checksum: 68ea4e07ff2c041ada184f9278b830375f8e0b75154e3f080af6b70f66172fabb4108d19b3863a96b53fc068a310b9b6493d86d1291acc5f3861eb4b79d26ad6
   languageName: node
   linkType: hard
 
@@ -2102,6 +2461,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-worker@npm:^27.4.5":
+  version: 27.5.1
+  resolution: "jest-worker@npm:27.5.1"
+  dependencies:
+    "@types/node": "*"
+    merge-stream: ^2.0.0
+    supports-color: ^8.0.0
+  checksum: 98cd68b696781caed61c983a3ee30bf880b5bd021c01d98f47b143d4362b85d0737f8523761e2713d45e18b4f9a2b98af1eaee77afade4111bb65c77d6f7c980
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -2118,6 +2488,13 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: bef146085f472d44dee30ec34e5cf36bf89164f5d585435a3d3da89e52622dff0b188a580e4ad091c3341889e14cb88cac6e4deb16dc5b1e9623bb0601fc255c
+  languageName: node
+  linkType: hard
+
+"json-parse-better-errors@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "json-parse-better-errors@npm:1.0.2"
+  checksum: ff2b5ba2a70e88fd97a3cb28c1840144c5ce8fae9cbeeddba15afa333a5c407cf0e42300cd0a2885dbb055227fe68d405070faad941beeffbfde9cf3b2c78c5d
   languageName: node
   linkType: hard
 
@@ -2186,6 +2563,13 @@ __metadata:
     prelude-ls: ^1.2.1
     type-check: ~0.4.0
   checksum: 12c5021c859bd0f5248561bf139121f0358285ec545ebf48bb3d346820d5c61a4309535c7f387ed7d84361cf821e124ce346c6b7cef8ee09a67c1473b46d0fc4
+  languageName: node
+  linkType: hard
+
+"loader-runner@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "loader-runner@npm:4.2.0"
+  checksum: e61aea8b6904b8af53d9de6f0484da86c462c0001f4511bedc837cec63deb9475cea813db62f702cd7930420ccb0e75c78112270ca5c8b61b374294f53c0cb3a
   languageName: node
   linkType: hard
 
@@ -2280,6 +2664,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"merge-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-stream@npm:2.0.0"
+  checksum: 6fa4dcc8d86629705cea944a4b88ef4cb0e07656ebf223fa287443256414283dd25d91c1cd84c77987f2aec5927af1a9db6085757cb43d90eb170ebf4b47f4f4
+  languageName: node
+  linkType: hard
+
 "merge2@npm:^1.3.0":
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
@@ -2294,6 +2685,22 @@ __metadata:
     braces: ^3.0.1
     picomatch: ^2.2.3
   checksum: ef3d1c88e79e0a68b0e94a03137676f3324ac18a908c245a9e5936f838079fcc108ac7170a5fadc265a9c2596963462e402841406bda1a4bb7b68805601d631c
+  languageName: node
+  linkType: hard
+
+"mime-db@npm:1.51.0":
+  version: 1.51.0
+  resolution: "mime-db@npm:1.51.0"
+  checksum: 613b1ac9d6e725cc24444600b124a7f1ce6c60b1baa654f39a3e260d0995a6dffc5693190217e271af7e2a5612dae19f2a73f3e316707d797a7391165f7ef423
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^2.1.27":
+  version: 2.1.34
+  resolution: "mime-types@npm:2.1.34"
+  dependencies:
+    mime-db: 1.51.0
+  checksum: 67013de9e9d6799bde6d669d18785b7e18bcd212e710d3e04a4727f92f67a8ad4e74aee24be28b685adb794944814bde649119b58ee3282ffdbee58f9278d9f3
   languageName: node
   linkType: hard
 
@@ -2434,6 +2841,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"neo-async@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "neo-async@npm:2.6.2"
+  checksum: deac9f8d00eda7b2e5cd1b2549e26e10a0faa70adaa6fdadca701cc55f49ee9018e427f424bac0c790b7c7e2d3068db97f3093f1093975f2acb8f8818b936ed9
+  languageName: node
+  linkType: hard
+
 "node-gyp@npm:latest":
   version: 8.4.1
   resolution: "node-gyp@npm:8.4.1"
@@ -2451,6 +2865,13 @@ __metadata:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 341710b5da39d3660e6a886b37e210d33f8282047405c2e62c277bcc744c7552c5b8b972ebc3a7d5c2813794e60cc48c3ebd142c46d6e0321db4db6c92dd0355
+  languageName: node
+  linkType: hard
+
+"node-releases@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "node-releases@npm:2.0.2"
+  checksum: da858bf86b4d512842379749f5a5e4196ddab05ba18ffcf29f05bf460beceaca927f070f4430bb5046efec18941ddbc85e4c5fdbb83afc28a38dd6069a2f255e
   languageName: node
   linkType: hard
 
@@ -2654,6 +3075,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picocolors@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "picocolors@npm:1.0.0"
+  checksum: a2e8092dd86c8396bdba9f2b5481032848525b3dc295ce9b57896f931e63fc16f79805144321f72976383fc249584672a75cc18d6777c6b757603f372f745981
+  languageName: node
+  linkType: hard
+
 "picomatch@npm:^2.2.2, picomatch@npm:^2.2.3":
   version: 2.3.0
   resolution: "picomatch@npm:2.3.0"
@@ -2748,6 +3176,15 @@ __metadata:
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
   checksum: b676f8c040cdc5b12723ad2f91414d267605b26419d5c821ff03befa817ddd10e238d22b25d604920340fd73efd8ba795465a0377c4adf45a4a41e4234e42dc4
+  languageName: node
+  linkType: hard
+
+"randombytes@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "randombytes@npm:2.1.0"
+  dependencies:
+    safe-buffer: ^5.1.0
+  checksum: d779499376bd4cbb435ef3ab9a957006c8682f343f14089ed5f27764e4645114196e75b7f6abf1cbd84fd247c0cb0651698444df8c9bf30e62120fbbc52269d6
   languageName: node
   linkType: hard
 
@@ -2937,7 +3374,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
@@ -2948,6 +3385,17 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
+  languageName: node
+  linkType: hard
+
+"schema-utils@npm:^3.1.0, schema-utils@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "schema-utils@npm:3.1.1"
+  dependencies:
+    "@types/json-schema": ^7.0.8
+    ajv: ^6.12.5
+    ajv-keywords: ^3.5.2
+  checksum: fb73f3d759d43ba033c877628fe9751620a26879f6301d3dbeeb48cf2a65baec5cdf99da65d1bf3b4ff5444b2e59cbe4f81c2456b5e0d2ba7d7fd4aed5da29ce
   languageName: node
   linkType: hard
 
@@ -2968,6 +3416,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 5eafe6102bea2a7439897c1856362e31cc348ccf96efd455c8b5bc2c61e6f7e7b8250dc26b8828c1d76a56f818a7ee907a36ae9fb37a599d3d24609207001d60
+  languageName: node
+  linkType: hard
+
+"serialize-javascript@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "serialize-javascript@npm:6.0.0"
+  dependencies:
+    randombytes: ^2.1.0
+  checksum: 56f90b562a1bdc92e55afb3e657c6397c01a902c588c0fe3d4c490efdcc97dcd2a3074ba12df9e94630f33a5ce5b76a74784a7041294628a6f4306e0ec84bf93
   languageName: node
   linkType: hard
 
@@ -3055,6 +3512,30 @@ __metadata:
     ip: ^1.1.5
     smart-buffer: ^4.1.0
   checksum: 2ca9d616e424f645838ebaabb04f85d94ea999e0f8393dc07f86c435af22ed88cb83958feeabd1bb7bc537c635ed47454255635502c6808a6df61af1f41af750
+  languageName: node
+  linkType: hard
+
+"source-map-support@npm:~0.5.20":
+  version: 0.5.21
+  resolution: "source-map-support@npm:0.5.21"
+  dependencies:
+    buffer-from: ^1.0.0
+    source-map: ^0.6.0
+  checksum: 43e98d700d79af1d36f859bdb7318e601dfc918c7ba2e98456118ebc4c4872b327773e5a1df09b0524e9e5063bb18f0934538eace60cca2710d1fa687645d137
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.6.0, source-map@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "source-map@npm:0.6.1"
+  checksum: 59ce8640cf3f3124f64ac289012c2b8bd377c238e316fb323ea22fbfe83da07d81e000071d7242cad7a23cd91c7de98e4df8830ec3f133cb6133a5f6e9f67bc2
+  languageName: node
+  linkType: hard
+
+"source-map@npm:~0.7.2":
+  version: 0.7.3
+  resolution: "source-map@npm:0.7.3"
+  checksum: cd24efb3b8fa69b64bf28e3c1b1a500de77e84260c5b7f2b873f88284df17974157cc88d386ee9b6d081f08fdd8242f3fc05c953685a6ad81aad94c7393dedea
   languageName: node
   linkType: hard
 
@@ -3178,6 +3659,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"supports-color@npm:^8.0.0":
+  version: 8.1.1
+  resolution: "supports-color@npm:8.1.1"
+  dependencies:
+    has-flag: ^4.0.0
+  checksum: c052193a7e43c6cdc741eb7f378df605636e01ad434badf7324f17fb60c69a880d8d8fcdcb562cf94c2350e57b937d7425ab5b8326c67c2adc48f7c87c1db406
+  languageName: node
+  linkType: hard
+
 "table@npm:^6.0.9":
   version: 6.7.3
   resolution: "table@npm:6.7.3"
@@ -3188,6 +3678,13 @@ __metadata:
     string-width: ^4.2.3
     strip-ansi: ^6.0.1
   checksum: 61d732f51108222d158eca2a91bfaae41c14e0cba6eb04c702ec5a1b136219d4925940d5c4d9aff5720bc4e2385dcbe2ed52dcf37bbbd8b2be48c01c1cf2ed1d
+  languageName: node
+  linkType: hard
+
+"tapable@npm:^2.1.1, tapable@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "tapable@npm:2.2.1"
+  checksum: 3b7a1b4d86fa940aad46d9e73d1e8739335efd4c48322cb37d073eb6f80f5281889bf0320c6d8ffcfa1a0dd5bfdbd0f9d037e252ef972aca595330538aac4d51
   languageName: node
   linkType: hard
 
@@ -3202,6 +3699,42 @@ __metadata:
     mkdirp: ^1.0.3
     yallist: ^4.0.0
   checksum: a04c07bb9e2d8f46776517d4618f2406fb977a74d914ad98b264fc3db0fe8224da5bec11e5f8902c5b9bcb8ace22d95fbe3c7b36b8593b7dfc8391a25898f32f
+  languageName: node
+  linkType: hard
+
+"terser-webpack-plugin@npm:^5.1.3":
+  version: 5.3.1
+  resolution: "terser-webpack-plugin@npm:5.3.1"
+  dependencies:
+    jest-worker: ^27.4.5
+    schema-utils: ^3.1.1
+    serialize-javascript: ^6.0.0
+    source-map: ^0.6.1
+    terser: ^5.7.2
+  peerDependencies:
+    webpack: ^5.1.0
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    esbuild:
+      optional: true
+    uglify-js:
+      optional: true
+  checksum: 1b808fd4f58ce0b532baacc50b9a850fc69ce0077a0e9e5076d4156c52fab3d40b02d5d9148a3eba64630cf7f40057de54f6a5a87fac1849b1f11d6bfdb42072
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.7.2":
+  version: 5.11.0
+  resolution: "terser@npm:5.11.0"
+  dependencies:
+    acorn: ^8.5.0
+    commander: ^2.20.0
+    source-map: ~0.7.2
+    source-map-support: ~0.5.20
+  bin:
+    terser: bin/terser
+  checksum: cc72b7a0e87421b5a6ef3f8a3c86ef251f6e7f8d6327b83c63045b8991a041cc4a42ea64e07701128e1786489902c8c44b5904056b0f12ceedb52924d493db04
   languageName: node
   linkType: hard
 
@@ -3351,6 +3884,60 @@ __metadata:
   version: 2.3.0
   resolution: "v8-compile-cache@npm:2.3.0"
   checksum: adb0a271eaa2297f2f4c536acbfee872d0dd26ec2d76f66921aa7fc437319132773483344207bdbeee169225f4739016d8d2dbf0553913a52bb34da6d0334f8e
+  languageName: node
+  linkType: hard
+
+"watchpack@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "watchpack@npm:2.3.1"
+  dependencies:
+    glob-to-regexp: ^0.4.1
+    graceful-fs: ^4.1.2
+  checksum: 70a34f92842d94b5d842980f866d568d7a467de667c96ae5759c759f46587e49265863171f4650bdbafc5f3870a28f2b4453e9e847098ec4b718b38926d47d22
+  languageName: node
+  linkType: hard
+
+"webpack-sources@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "webpack-sources@npm:3.2.3"
+  checksum: 989e401b9fe3536529e2a99dac8c1bdc50e3a0a2c8669cbafad31271eadd994bc9405f88a3039cd2e29db5e6d9d0926ceb7a1a4e7409ece021fe79c37d9c4607
+  languageName: node
+  linkType: hard
+
+"webpack@npm:^5.69.1":
+  version: 5.69.1
+  resolution: "webpack@npm:5.69.1"
+  dependencies:
+    "@types/eslint-scope": ^3.7.3
+    "@types/estree": ^0.0.51
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/wasm-edit": 1.11.1
+    "@webassemblyjs/wasm-parser": 1.11.1
+    acorn: ^8.4.1
+    acorn-import-assertions: ^1.7.6
+    browserslist: ^4.14.5
+    chrome-trace-event: ^1.0.2
+    enhanced-resolve: ^5.8.3
+    es-module-lexer: ^0.9.0
+    eslint-scope: 5.1.1
+    events: ^3.2.0
+    glob-to-regexp: ^0.4.1
+    graceful-fs: ^4.2.9
+    json-parse-better-errors: ^1.0.2
+    loader-runner: ^4.2.0
+    mime-types: ^2.1.27
+    neo-async: ^2.6.2
+    schema-utils: ^3.1.0
+    tapable: ^2.1.1
+    terser-webpack-plugin: ^5.1.3
+    watchpack: ^2.3.1
+    webpack-sources: ^3.2.3
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: 490a6e9e4cd9d0ed3b6c7ca08015da2628919fda8fcf9c36f0f6c0e3ad71eaaaf4b0d12753109f22a4faf79fe9a9063552d9708e0ee2352cf8568433b8e296a7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes [HAC-491](https://issues.redhat.com/browse/HAC-491)

- add `lib-webpack`
  - to be distributed as `@openshift/dynamic-plugin-sdk-webpack`
  - has peer dependency on core package `@openshift/dynamic-plugin-sdk`

- update `lib-core`
  - name of the global callback function is fixed to `__load_plugin_entry__`
  - expose support APIs (types and code) for use in `lib-webpack`

- update `lib-*`
  - move utility-like dependencies from `peerDependencies` & `devDependencies` to `dependencies`
