### PR TITLE
Bump lib package versions

### DIFF
--- a/packages/lib-core/package.json
+++ b/packages/lib-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk",
-  "version": "0.0.0-alpha1",
+  "version": "1.0.0-alpha1",
   "description": "Allows loading, managing and interpreting plugins",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-utils",
-  "version": "0.0.0-alpha1",
+  "version": "1.0.0-alpha1",
   "description": "Provides Kubernetes and React utilities",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
[SemVer spec](https://semver.org/) says

> Major version zero (0.y.z) is for initial development. Anything MAY change at any time.

this is sometimes referred to as "the escape clause" for `0.y.z` versions. (See [this article](https://nodesource.com/blog/semver-tilde-and-caret/) for details.)

This PR bumps all lib packages to `1.0.0-alpha1` since we're close to publishing their first versions.
