### PR TITLE
Fix webpack import by importing default, instead of star

### DIFF
--- a/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
+++ b/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
@@ -7,7 +7,7 @@ import type { Extension } from '@openshift/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
 import * as glob from 'glob';
 import * as path from 'path';
-import * as webpack from 'webpack';
+import webpack from 'webpack';
 import type { PluginBuildMetadata } from '../types/plugin';
 import { parseJSONFile } from '../utils/json';
 import { pluginBuildMetadataSchema } from '../yup-schemas';

--- a/packages/lib-webpack/src/webpack/GenerateManifestPlugin.ts
+++ b/packages/lib-webpack/src/webpack/GenerateManifestPlugin.ts
@@ -1,6 +1,6 @@
 import { PLUGIN_MANIFEST } from '@openshift/dynamic-plugin-sdk';
 import type { PluginManifest } from '@openshift/dynamic-plugin-sdk';
-import * as webpack from 'webpack';
+import webpack from 'webpack';
 
 export class GenerateManifestPlugin implements webpack.WebpackPluginInstance {
   constructor(private readonly manifest: PluginManifest) {}

--- a/packages/lib-webpack/src/webpack/PatchContainerEntryPlugin.ts
+++ b/packages/lib-webpack/src/webpack/PatchContainerEntryPlugin.ts
@@ -1,5 +1,5 @@
 import { REMOTE_ENTRY_SCRIPT } from '@openshift/dynamic-plugin-sdk';
-import * as webpack from 'webpack';
+import webpack from 'webpack';
 
 export class PatchContainerEntryPlugin implements webpack.WebpackPluginInstance {
   constructor(private readonly callbackName: string, private readonly pluginID: string) {}


### PR DESCRIPTION
### Adjust webpack import

Since webpack exports just default export we have to adjust the import to it. With the current import we'd have to access it as `webpack.default.`. This is generally a pitfall of using `*` import as it means `import everything` and if some module exports `default` and not named exports it will fail.