### PR TITLE
HAC-488: Migrate API Discovery logic to SDK

### DIFF
--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "immutable": "^3.8.2",
     "lodash-es": "^4.17.21",
+    "pluralize": "^8.0.0",
     "typesafe-actions": "^4.4.2"
   },
   "devDependencies": {
@@ -41,6 +42,7 @@
     "@rollup/plugin-node-resolve": "^13.1.1",
     "@rollup/plugin-typescript": "^8.3.0",
     "@types/lodash-es": "^4.17.5",
+    "@types/pluralize": "^0.0.29",
     "@types/react": "^17.0.37",
     "react": "^17.0.2",
     "react-redux": "^7.2.2",

--- a/packages/lib-utils/src/app/api-discovery/discovery-cache.ts
+++ b/packages/lib-utils/src/app/api-discovery/discovery-cache.ts
@@ -1,0 +1,32 @@
+import { consoleLogger } from '@monorepo/common';
+import type { DiscoveryResources } from '../../types/api-discovery';
+
+const SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = 'sdk/api-discovery-resources';
+
+export const cacheResources = (resources: DiscoveryResources) => {
+  try {
+    localStorage.setItem(SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY, JSON.stringify(resources));
+  } catch (e) {
+    consoleLogger.error('Error caching API resources in localStorage', e);
+    throw e;
+  }
+};
+
+export const getCachedResources = async () => {
+  const resourcesJSON = localStorage.getItem(SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY);
+  if (!resourcesJSON) {
+    throw new Error(
+      `No API resources found in localStorage for key ${SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY}`,
+    );
+  }
+
+  // Clear cached resources after load as a safeguard. If there's any errors
+  // with the content that prevents the console from working, the bad data
+  // will not be loaded when the user refreshes the console. The cache will
+  // be refreshed when discovery completes.
+  localStorage.removeItem(SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY);
+
+  const resources = JSON.parse(resourcesJSON);
+  consoleLogger.info('Loaded cached API resources from localStorage');
+  return resources;
+};

--- a/packages/lib-utils/src/app/api-discovery/index.ts
+++ b/packages/lib-utils/src/app/api-discovery/index.ts
@@ -1,6 +1,179 @@
-import type { InitAPIDiscovery } from '../../types/api-discovery';
+import type { AnyObject } from '@monorepo/common';
+import { consoleLogger } from '@monorepo/common';
+import * as _ from 'lodash-es';
+import { plural } from 'pluralize';
+import type { Dispatch } from 'redux';
+import { kindToAbbr } from '../../k8s/k8s-resource';
+import type {
+  APIResourceList,
+  DiscoveryResources,
+  InitAPIDiscovery,
+} from '../../types/api-discovery';
+import type { K8sModelCommon } from '../../types/k8s';
+import type { DispatchWithThunk } from '../../types/redux';
+import { commonFetchJSON } from '../../utils/common-fetch';
+import { getResourcesInFlight, receivedResources } from '../redux/actions/k8s';
+import { cacheResources, getCachedResources } from './discovery-cache';
 
-// TODO remove when API discovery is migrated
+const POLLs: { [id: string]: number } = {};
+const apiDiscovery = 'apiDiscovery';
+const API_DISCOVERY_POLL_INTERVAL = 60_000;
+
+const pluralizeKind = (kind: string): string => {
+  // Use startCase to separate words so the last can be pluralized but remove spaces so as not to humanize
+  const pluralized = plural(_.startCase(kind)).replace(/\s+/g, '');
+  // Handle special cases like DB -> DBs (instead of DBS).
+  if (pluralized === `${kind}S`) {
+    return `${kind}s`;
+  }
+  return pluralized;
+};
+
+const defineModels = (list: APIResourceList): K8sModelCommon[] => {
+  const { apiGroup, apiVersion } = list;
+  if (!list.resources || list.resources.length < 1) {
+    return [];
+  }
+  return list.resources
+    .filter(({ name }) => !name.includes('/'))
+    .map(
+      ({ name, singularName, namespaced, kind, verbs, shortNames }) =>
+        <K8sModelCommon>{
+          ...(apiGroup ? { apiGroup } : {}),
+          apiVersion,
+          kind,
+          namespaced,
+          verbs,
+          shortNames,
+          plural: name,
+          crd: true,
+          abbr: kindToAbbr(kind),
+          labelPlural: pluralizeKind(kind),
+          path: name,
+          id: singularName,
+          label: kind,
+        },
+    );
+};
+
+type APIResourceData = {
+  groups: {
+    name: string;
+    versions: {
+      groupVersion: unknown;
+    }[];
+    preferredVersion: { version: unknown };
+  }[];
+};
+
+const getResources = async (): Promise<DiscoveryResources> => {
+  const apiResourceData: APIResourceData = await commonFetchJSON('/apis');
+  const groupVersionMap = apiResourceData.groups.reduce(
+    (acc: AnyObject, { name, versions, preferredVersion: { version } }) => {
+      acc[name] = {
+        versions: _.map(versions, 'version'),
+        preferredVersion: version,
+      };
+      return acc;
+    },
+    {},
+  );
+  const all: Promise<APIResourceList>[] = _.flatten(
+    apiResourceData.groups.map((group) =>
+      group.versions.map((version) => `/apis/${version.groupVersion}`),
+    ),
+  )
+    .concat(['/api/v1'])
+    .map((p) => commonFetchJSON<K8sModelCommon>(`api/kubernetes${p}`).catch((err) => err));
+
+  return Promise.all(all).then((data) => {
+    const resourceSet = new Set<string>();
+    const namespacedSet = new Set<string>();
+    data.forEach(
+      (d) =>
+        d.resources &&
+        d.resources.forEach(({ namespaced, name }) => {
+          resourceSet.add(name);
+          if (namespaced) {
+            namespacedSet.add(name);
+          }
+        }),
+    );
+    const allResources = [...resourceSet].sort();
+
+    const safeResources: string[] = [];
+    const adminResources: string[] = [];
+    const models = _.flatten(data.filter((d) => d.resources).map(defineModels));
+    const coreResources = new Set([
+      'roles',
+      'rolebindings',
+      'clusterroles',
+      'clusterrolebindings',
+      'thirdpartyresources',
+      'nodes',
+      'secrets',
+    ]);
+    allResources.forEach((r) =>
+      coreResources.has(r.split('/')[0]) ? adminResources.push(r) : safeResources.push(r),
+    );
+    const configResources = _.filter(
+      models,
+      (m) => m.apiGroup === 'config.openshift.io' && m.kind !== 'ClusterOperator',
+    );
+    const clusterOperatorConfigResources = _.filter(
+      models,
+      (m) => m.apiGroup === 'operator.openshift.io',
+    );
+
+    return {
+      allResources,
+      safeResources,
+      adminResources,
+      configResources,
+      clusterOperatorConfigResources,
+      namespacedSet,
+      models,
+      groupVersionMap,
+    } as DiscoveryResources;
+  });
+};
+
+const updateResources = () => (dispatch: Dispatch) => {
+  dispatch(getResourcesInFlight());
+
+  getResources()
+    .then((resources) => {
+      // Cache the resources whenever discovery completes to improve console load times.
+      cacheResources(resources);
+      dispatch(receivedResources(resources));
+      return resources;
+    })
+    .catch((err) => consoleLogger.error('Fetching resource failed:', err));
+};
+
+const startAPIDiscovery = () => (dispatch: DispatchWithThunk) => {
+  consoleLogger.info('API discovery method: Polling');
+  // Poll API discovery every 30 seconds since we can't watch CRDs
+  dispatch(updateResources());
+  if (POLLs[apiDiscovery]) {
+    clearTimeout(POLLs[apiDiscovery]);
+    delete POLLs[apiDiscovery];
+  }
+  POLLs[apiDiscovery] = window.setTimeout(
+    () => dispatch(startAPIDiscovery()),
+    API_DISCOVERY_POLL_INTERVAL,
+  );
+};
+
 export const initAPIDiscovery: InitAPIDiscovery = (storeInstance) => {
-  return storeInstance;
+  getCachedResources()
+    .then((resources) => {
+      if (resources) {
+        storeInstance.dispatch(receivedResources(resources));
+      }
+      // Still perform discovery to refresh the cache.
+      storeInstance.dispatch(startAPIDiscovery());
+      return resources;
+    })
+    .catch(() => storeInstance.dispatch(startAPIDiscovery()));
 };

--- a/packages/lib-utils/src/k8s/k8s-resource.ts
+++ b/packages/lib-utils/src/k8s/k8s-resource.ts
@@ -153,3 +153,16 @@ export const k8sListResource = <TResource extends K8sResourceCommon>({
 export const k8sListResourceItems = <TResource extends K8sResourceCommon>(
   options: K8sResourceListOptions,
 ): Promise<TResource[]> => k8sListResource<TResource>(options).then((result) => result.items);
+
+const abbrBlacklist = ['ASS'];
+
+/**
+ * Provides an abbreviation string for given kind with respect to abbrBlacklist.
+ * @param kind Kind for which the abbreviation is generated.
+ * @return Abbreviation string for given kind.
+ * TODO: Use in resource-icon component once it is being migrated to the SDK.
+ * * */
+export const kindToAbbr = (kind: string) => {
+  const abbrKind = (kind.replace(/[^A-Z]/g, '') || kind.toUpperCase()).slice(0, 4);
+  return abbrBlacklist.includes(abbrKind) ? abbrKind.slice(0, -1) : abbrKind;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -215,9 +215,11 @@ __metadata:
     "@rollup/plugin-node-resolve": ^13.1.1
     "@rollup/plugin-typescript": ^8.3.0
     "@types/lodash-es": ^4.17.5
+    "@types/pluralize": ^0.0.29
     "@types/react": ^17.0.37
     immutable: ^3.8.2
     lodash-es: ^4.17.21
+    pluralize: ^8.0.0
     react: ^17.0.2
     react-redux: ^7.2.2
     redux: ^4.1.2
@@ -459,6 +461,13 @@ __metadata:
   version: 16.11.12
   resolution: "@types/node@npm:16.11.12"
   checksum: a3feb346d61a56f5a137c29bb8c63cfa3cc02e184b9dffdc18ef1528dcce55596e570575215a2e39e6ce69343eeb2a5ba71c271938f1dc8db4cc393902855412
+  languageName: node
+  linkType: hard
+
+"@types/pluralize@npm:^0.0.29":
+  version: 0.0.29
+  resolution: "@types/pluralize@npm:0.0.29"
+  checksum: db7732b733ba1dc59f080f87364c9f985c1ae9f1e5ec5fcefb83c1327149e01ecac42766352eb7b19b117cf39defa99cf514629f3666968a3bdeb00e74f2a97e
   languageName: node
   linkType: hard
 
@@ -3150,6 +3159,13 @@ __metadata:
   dependencies:
     find-up: ^2.1.0
   checksum: 8c72b712305b51e1108f0ffda5ec1525a8307e54a5855db8fb1dcf77561a5ae98e2ba3b4814c9806a679f76b2f7e5dd98bde18d07e594ddd9fdd25e9cf242ea1
+  languageName: node
+  linkType: hard
+
+"pluralize@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "pluralize@npm:8.0.0"
+  checksum: 08931d4a6a4a5561a7f94f67a31c17e6632cb21e459ab3ff4f6f629d9a822984cf8afef2311d2005fbea5d7ef26016ebb090db008e2d8bce39d0a9a9d218736e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Migrates API discovery functions to the SDK.

See https://issues.redhat.com/browse/HAC-488