### PR TITLE
Support null as a value to useK8sWatchResource

### DIFF
--- a/packages/lib-utils/src/k8s/hooks/watch-resource-types.ts
+++ b/packages/lib-utils/src/k8s/hooks/watch-resource-types.ts
@@ -51,7 +51,7 @@ export type WatchK8sResources<R extends ResourcesObject> = {
 };
 
 export type UseK8sWatchResource = <R extends K8sResourceCommon | K8sResourceCommon[]>(
-  initResource: WatchK8sResource,
+  initResource: WatchK8sResource | null,
 ) => WatchK8sResult<R>;
 
 export type UseK8sWatchResources = <R extends ResourcesObject>(


### PR DESCRIPTION
`null` is a needed value to support use-cases that need to be based off a value with an external optional condition ([example](https://github.com/openshift-assisted/dynamic-cim/blob/f358e35cbb92426bcef833eb6d3e74680ca96544/src/components/Agent/AgentTable.tsx#L26-L35)). 