### PR TITLE
Bump lib package versions before publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npm login --scope=@openshift
 To see the latest published version of the given package:
 
 ```sh
-npm view $(jq -r .name < packages/<PKG_DIR>/package.json) dist-tags.latest
+npm view $(jq -r .name < ./packages/<PKG_DIR>/package.json) dist-tags.latest
 ```
 
 Make sure the `version` field in the relevant `package.json` file(s) has the right value.
@@ -64,7 +64,7 @@ Make sure the `version` field in the relevant `package.json` file(s) has the rig
 To verify the package before publishing:
 
 ```sh
-npm publish packages/<PKG_DIR> --no-git-tag-version --dry-run
+npm publish ./packages/<PKG_DIR> --no-git-tag-version --dry-run
 ```
 
 To publish the package, run the above command without `--dry-run` parameter.

--- a/packages/lib-core/package.json
+++ b/packages/lib-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk",
-  "version": "1.0.0-alpha1",
+  "version": "1.0.0-alpha2",
   "description": "Allows loading, managing and interpreting plugins",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-utils",
-  "version": "1.0.0-alpha2",
+  "version": "1.0.0-alpha3",
   "description": "Provides Kubernetes and React utilities",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/lib-webpack/package.json
+++ b/packages/lib-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-webpack",
-  "version": "1.0.0-alpha1",
+  "version": "1.0.0-alpha2",
   "description": "Allows building plugin assets with webpack",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
All `lib-*` packages have changes since their last publish.

Includes a small README update; seems like [`npm publish`](https://docs.npmjs.com/cli/v8/commands/npm-publish) trips over relative paths that don't start with `./` prefix.
