### PR TITLE
Bump lib versions

### DIFF
--- a/docs/publish-packages.md
+++ b/docs/publish-packages.md
@@ -37,6 +37,10 @@ npm view $(jq -r .name < ./packages/PKG_DIR/package.json) dist-tags.latest
 
 Make sure the `version` field in the relevant `package.json` file(s) has the right value.
 
+```sh
+npm pkg set version='NEW_VERSION' -workspace ./packages/PKG_DIR
+```
+
 To verify the package before publishing:
 
 ```sh

--- a/packages/lib-core/package.json
+++ b/packages/lib-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk",
-  "version": "1.0.0-alpha2",
+  "version": "1.0.0-alpha4",
   "description": "Allows loading, managing and interpreting dynamic plugins",
   "license": "Apache-2.0",
   "repository": {
@@ -12,6 +12,7 @@
     "dist/index.js",
     "dist/index.d.ts"
   ],
+  "main": "dist/index.js",
   "scripts": {
     "prepack": "yarn build",
     "prepublishOnly": "yarn test",
@@ -35,8 +36,5 @@
     "redux": {
       "optional": true
     }
-  },
-  "publishConfig": {
-    "main": "index.js"
   }
 }

--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-utils",
-  "version": "1.0.0-alpha4",
+  "version": "1.0.0-alpha5",
   "description": "Provides React focused plugin SDK initialization and utilities",
   "license": "Apache-2.0",
   "repository": {
@@ -12,6 +12,7 @@
     "dist/index.js",
     "dist/index.d.ts"
   ],
+  "main": "dist/index.js",
   "scripts": {
     "prepack": "yarn build",
     "prepublishOnly": "yarn test",
@@ -34,8 +35,5 @@
   },
   "devDependencies": {
     "@openshift/dynamic-plugin-sdk": "link:../lib-core/dist"
-  },
-  "publishConfig": {
-    "main": "index.js"
   }
 }

--- a/packages/lib-webpack/package.json
+++ b/packages/lib-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-webpack",
-  "version": "1.0.0-alpha2",
+  "version": "1.0.0-alpha3",
   "description": "Allows building dynamic plugin assets with webpack",
   "license": "Apache-2.0",
   "repository": {
@@ -12,6 +12,7 @@
     "dist/index.js",
     "dist/index.d.ts"
   ],
+  "main": "dist/index.js",
   "scripts": {
     "prepack": "yarn build",
     "prepublishOnly": "yarn test",
@@ -26,9 +27,6 @@
     "glob": "^7.2.0",
     "lodash": "^4.17.21",
     "yup": "^0.32.11"
-  },
-  "publishConfig": {
-    "main": "index.js"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
Go back to using the `main` field in `package.json` files of dist packages, since `npm` CLI doesn't support setting its value right before publish via `publishConfig` option.

(Note that [Yarn](https://yarnpkg.com/configuration/manifest/#publishConfig) and [pnpm](https://pnpm.io/package_json#publishconfig) support this use case, so I guess it's an extension of the official `npm` functionality.)