### PR TITLE
Bump lib-utils to @openshift/dynamic-plugin-sdk-utils@1.0.0-alpha7

### DIFF
--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-utils",
-  "version": "1.0.0-alpha6",
+  "version": "1.0.0-alpha7",
   "description": "Provides React focused plugin SDK initialization and utilities",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Includes fixes for the `useK8sWatchResource` hooks