### PR TITLE
Allow passthru param on ws.destory()

### DIFF
--- a/packages/lib-utils/src/app/redux/actions/k8s.ts
+++ b/packages/lib-utils/src/app/redux/actions/k8s.ts
@@ -216,9 +216,10 @@ export const watchK8sList =
           }
           consoleLogger.info('WS closed abnormally - starting polling loop over!');
           const ws = WS[id];
-          ws?.destroy();
+          const timedOut = true;
+          ws?.destroy(timedOut);
         })
-        .onDestroy((timedOut: boolean) => {
+        .onDestroy((timedOut) => {
           if (!timedOut) {
             return;
           }

--- a/packages/lib-utils/src/web-socket/WebSocketFactory.ts
+++ b/packages/lib-utils/src/web-socket/WebSocketFactory.ts
@@ -313,7 +313,7 @@ export class WebSocketFactory {
   /**
    * Cleans up the web socket instance and related internal data.
    */
-  destroy(): void {
+  destroy(eventData?: unknown): void {
     consoleLogger.info(`destroying websocket: ${this.id}`);
     if (this.state === WebSocketState.DESTROYED) {
       return;
@@ -339,7 +339,7 @@ export class WebSocketFactory {
     }
 
     try {
-      this.triggerEvent('destroy');
+      this.triggerEvent('destroy', eventData);
     } catch (e) {
       consoleLogger.error('Error while trigger destroy event for web socket', e);
     }

--- a/packages/lib-utils/src/web-socket/types.ts
+++ b/packages/lib-utils/src/web-socket/types.ts
@@ -93,7 +93,10 @@ export type OpenHandler = GenericHandler<never>;
 export type CloseHandler = GenericHandler<CloseEvent>;
 export type ErrorHandler = GenericHandler<Event>;
 export type MessageHandler = GenericHandler<MessageDataType>;
-export type DestroyHandler = GenericHandler<never>;
+/**
+ * Data is provided potentially by .destroy() caller.
+ */
+export type DestroyHandler = GenericHandler<unknown | undefined>;
 export type BulkMessageHandler = GenericHandler<MessageDataType[]>;
 
 export type EventHandlers = {


### PR DESCRIPTION
Fix from https://github.com/openshift/console/pull/11288 propagated into the SDK. 

Effectively the issue in OpenShift Console was the `.onDestory` callback was waiting for a param that was supposed to be provided by the `.destory()` call made a few lines above. 

Kinda surprised the `GenericHandler<never>` type didn't cause a TS issue with us having a variable in the `.onDestory(timedOut)` callback 🤔 