### PR TITLE
Add filtering to Table component

### DIFF
--- a/packages/lib-utils/src/components/status/StatusBox.tsx
+++ b/packages/lib-utils/src/components/status/StatusBox.tsx
@@ -3,11 +3,14 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 
 export type LoadError = {
+  /** Error message. */
   message: string;
+  /** Error HTTP status code. */
   status: number;
 };
 
 type AccessDeniedProps = {
+  /** Access denied message. */
   message: string | React.ComponentType;
 };
 
@@ -28,14 +31,23 @@ export const AccessDenied: React.FC<AccessDeniedProps> = ({
 );
 
 export type StatusBoxProps = {
+  /** Optional flag indicating that external filters are applied. */
   areFiltersApplied?: boolean;
+  /** Flag indicating that there is no data. */
   noData: boolean;
+  /** Optional children component containing rendered data. */
   children?: React.ReactElement;
+  /** Optional label used where there is no data. */
   emptyLabel?: string;
+  /** Optional load error object. */
   loadError?: LoadError;
+  /** Data loaded flag. */
   loaded?: boolean;
+  /** Optional default message used when data loading fails. */
   LoadErrorDefaultMsg?: React.ComponentType;
+  /** Optional message used when there is no data at all. */
   NoDataEmptyMsg?: React.ComponentType;
+  /** Optional message used when there is no relevant data. */
   EmptyMsg?: React.ComponentType;
 };
 

--- a/packages/lib-utils/src/components/table-view/TableView.tsx
+++ b/packages/lib-utils/src/components/table-view/TableView.tsx
@@ -1,0 +1,151 @@
+import {
+  Button,
+  ButtonVariant,
+  Chip,
+  ChipGroup,
+  SearchInput,
+  Select,
+  SelectOption,
+  SelectVariant,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+  ToolbarItemVariant,
+} from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons';
+import { omit } from 'lodash';
+import * as React from 'react';
+import type { TableProps } from '../table/Table';
+import Table from '../table/Table';
+import './table-view.scss';
+
+export type FilterItem = {
+  /* Label of a parameter used for filtering. */
+  label: string;
+  /* Column name for given filtering parameter. */
+  id: string;
+};
+
+export type TableViewProps<D> = TableProps<D> & {
+  /* Optional custom onFilter callback. */
+  onFilter?: (filterValues: Record<string, string>, activeFilter?: FilterItem) => D[];
+  /* Optional array of filterBy options. */
+  filters?: FilterItem[];
+};
+
+const TableView: React.FC<TableViewProps<Record<string, unknown>>> = ({
+  areFiltersApplied,
+  data,
+  loaded,
+  loadError,
+  columns,
+  Row,
+  LoadErrorDefaultMsg,
+  NoDataEmptyMsg,
+  onFilter,
+  filters,
+  EmptyMsg,
+  emptyLabel,
+  'aria-label': ariaLabel,
+}) => {
+  const [activeFilter, setActiveFilter] = React.useState<FilterItem | undefined>(filters?.[0]);
+  const [filterValues, setFilterValues] = React.useState<Record<string, string>>({});
+  const [filteredData, setFilteredData] = React.useState(data);
+  const [isFilterSelectExpanded, setFilterSelectExpanded] = React.useState(false);
+
+  React.useEffect(() => {
+    if (filters) {
+      setFilteredData(
+        onFilter
+          ? onFilter(filterValues, activeFilter)
+          : [...data].filter((item: Record<string, unknown>) =>
+              Object.keys(filterValues).every((key) =>
+                (item[key] as string)?.toLowerCase()?.includes(filterValues[key]?.toLowerCase()),
+              ),
+            ),
+      );
+    }
+  }, [activeFilter, data, filterValues, filters, onFilter]);
+
+  return (
+    <>
+      {filters ? (
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarItem key="filter-select">
+              <Select
+                toggleIcon={<FilterIcon />}
+                variant={SelectVariant.single}
+                onToggle={(value) => setFilterSelectExpanded(value)}
+                onSelect={(e, selection) => {
+                  setActiveFilter(filters.find((item) => item.id === selection));
+                  setFilterSelectExpanded(false);
+                }}
+                placeholderText={activeFilter?.label}
+                isOpen={isFilterSelectExpanded}
+              >
+                {filters?.map((option) => (
+                  <SelectOption key={option.id} value={option.id}>
+                    {option.label}
+                  </SelectOption>
+                ))}
+              </Select>
+            </ToolbarItem>
+            <ToolbarItem variant={ToolbarItemVariant['search-filter']} key="search-filter">
+              <SearchInput
+                className="dps-table-view-search"
+                onChange={(value) =>
+                  activeFilter &&
+                  setFilterValues({
+                    ...filterValues,
+                    [activeFilter.id]: value,
+                  })
+                }
+                value={activeFilter ? filterValues[activeFilter.id] : ''}
+                placeholder={`Filter by ${activeFilter?.label}`}
+              />
+            </ToolbarItem>
+            {Object.keys(filterValues).map((key) =>
+              filterValues[key]?.length > 0 ? (
+                <ToolbarItem variant={ToolbarItemVariant['chip-group']} key={`chips-${key}`}>
+                  <ChipGroup categoryName={filters.find((item) => item.id === key)?.label}>
+                    <Chip
+                      key={filterValues[key]}
+                      onClick={() => setFilterValues(omit(filterValues, key))}
+                    >
+                      {filterValues[key]}
+                    </Chip>
+                  </ChipGroup>
+                </ToolbarItem>
+              ) : null,
+            )}
+            {Object.values(filterValues).some((value) => value?.length > 0) ? (
+              <ToolbarItem key="delete-chips" className="dps-table-view-clear">
+                <Button variant={ButtonVariant.link} onClick={() => setFilterValues({})} isInline>
+                  Clear all filters
+                </Button>
+              </ToolbarItem>
+            ) : null}
+          </ToolbarContent>
+        </Toolbar>
+      ) : null}
+      <Table
+        areFiltersApplied={
+          areFiltersApplied || Object.values(filterValues).some((value) => value?.length > 0)
+        }
+        data={filteredData}
+        loaded={loaded}
+        loadError={loadError}
+        columns={columns}
+        Row={Row}
+        LoadErrorDefaultMsg={LoadErrorDefaultMsg}
+        NoDataEmptyMsg={NoDataEmptyMsg}
+        EmptyMsg={EmptyMsg}
+        emptyLabel={emptyLabel}
+        aria-label={ariaLabel}
+      />
+    </>
+  );
+};
+
+export default TableView;

--- a/packages/lib-utils/src/components/table-view/TableView.tsx
+++ b/packages/lib-utils/src/components/table-view/TableView.tsx
@@ -20,16 +20,16 @@ import Table from '../table/Table';
 import './table-view.scss';
 
 export type FilterItem = {
-  /* Label of a parameter used for filtering. */
+  /** Label of a parameter used for filtering. */
   label: string;
-  /* Column name for given filtering parameter. */
+  /** Column name for given filtering parameter. */
   id: string;
 };
 
 export type TableViewProps<D> = TableProps<D> & {
-  /* Optional custom onFilter callback. */
+  /** Optional custom onFilter callback. */
   onFilter?: (filterValues: Record<string, string>, activeFilter?: FilterItem) => D[];
-  /* Optional array of filterBy options. */
+  /** Optional array of filterBy options. */
   filters?: FilterItem[];
 };
 

--- a/packages/lib-utils/src/components/table-view/table-view.scss
+++ b/packages/lib-utils/src/components/table-view/table-view.scss
@@ -1,0 +1,9 @@
+.pf-c-search-input.dps-table-view-search {
+  margin-right: var(--pf-global--spacer--sm);
+}
+
+.pf-c-toolbar__item.dps-table-view-clear {
+  margin-left: var(--pf-global--spacer--md);
+  padding-bottom: var(--pf-global--spacer--sm);
+  padding-top: var(--pf-global--spacer--sm);
+}

--- a/packages/lib-utils/src/components/table/Table.tsx
+++ b/packages/lib-utils/src/components/table/Table.tsx
@@ -7,26 +7,41 @@ import type { LoadError } from '../status/StatusBox';
 import { StatusBox } from '../status/StatusBox';
 
 export type RowProps<D> = {
+  /** Row data object. */
   obj: D;
 };
 
 export type TableColumn = ICell & {
+  /** Column title. */
   title: string;
+  /** Column id. */
   id: string;
+  /** Optional sort attribute - please do not use string value (deprecated). */
   sort?: ThProps['sort'] | string;
 };
 
 export type TableProps<D> = {
+  /** Optional flag indicating that external filters are applied. */
   areFiltersApplied?: boolean;
+  /** Data array. */
   data: D[];
+  /** Data loaded flag. */
   loaded: boolean;
+  /** Optional load error object. */
   loadError?: LoadError;
+  /** Table volumns. */
   columns: TableColumn[];
+  /** Table row component used for rendering rows. */
   Row: React.FC<RowProps<D>>;
+  /** Optional default message used when data loading fails. */
   LoadErrorDefaultMsg?: React.ComponentType;
+  /** Optional message used when there is no data. */
   NoDataEmptyMsg?: React.ComponentType;
+  /** Optional message used when there is no data after filtering. */
   EmptyMsg?: React.ComponentType;
+  /** Optional label used where there is no data. */
   emptyLabel?: string;
+  /** Optional aria label. */
   'aria-label'?: string;
 };
 


### PR DESCRIPTION
[HAC-1012](https://issues.redhat.com/browse/HAC-1012)

![filtering](https://user-images.githubusercontent.com/50696716/164260104-9568fb1a-ee34-4131-a9fe-77fef8f109bd.png)

Added multi-column filtering to the table component. User can apply filters to multiple columns at the same time and clear the filters. Component allows passing a custom `onFilter` component. If no `filters` array is passed, user can use the component completely without filtering - pagination will be added to it in a follow-up.

Also added comments to `Table` and `StatusBox` props.

@florkbr 