### PR TITLE
Consume preferenceList to sort API discovery based on

### DIFF
--- a/packages/lib-utils/src/app/AppInitSDK.tsx
+++ b/packages/lib-utils/src/app/AppInitSDK.tsx
@@ -12,6 +12,7 @@ import { useReduxStore } from './redux';
 type AppInitSDKProps = {
   configurations: {
     apiDiscovery?: InitAPIDiscovery;
+    apiPriorityList?: string[];
     appFetch: UtilsConfig['appFetch'];
     pluginStore: PluginStore;
     wsAppSettings: UtilsConfig['wsAppSettings'];
@@ -38,18 +39,24 @@ type AppInitSDKProps = {
 const AppInitSDK: React.FC<AppInitSDKProps> = ({ children, configurations }) => {
   const { store, storeContextPresent } = useReduxStore();
 
-  const { appFetch, pluginStore, wsAppSettings, apiDiscovery = initAPIDiscovery } = configurations;
+  const {
+    appFetch,
+    pluginStore,
+    wsAppSettings,
+    apiDiscovery = initAPIDiscovery,
+    apiPriorityList,
+  } = configurations;
 
   React.useEffect(() => {
     try {
       if (!isUtilsConfigSet()) {
         setUtilsConfig({ appFetch, wsAppSettings });
       }
-      apiDiscovery(store);
+      apiDiscovery(store, apiPriorityList);
     } catch (e) {
       consoleLogger.warn('Error while initializing AppInitSDK', e);
     }
-  }, [apiDiscovery, appFetch, store, wsAppSettings]);
+  }, [apiDiscovery, appFetch, store, wsAppSettings, apiPriorityList]);
 
   return (
     <PluginStoreProvider store={pluginStore}>

--- a/packages/lib-utils/src/types/api-discovery.ts
+++ b/packages/lib-utils/src/types/api-discovery.ts
@@ -2,7 +2,10 @@ import type { Store, AnyAction } from 'redux';
 import type { ActionType as Action } from 'typesafe-actions';
 import type { K8sVerb, K8sModelCommon } from './k8s';
 
-export type InitAPIDiscovery = (store: Store<unknown, Action<AnyAction>>) => void;
+export type InitAPIDiscovery = (
+  store: Store<unknown, Action<AnyAction>>,
+  preferenceList?: string[],
+) => void;
 
 export type APIResourceList = K8sModelCommon & {
   kind: 'APIResourceList';


### PR DESCRIPTION
## Watch improvements
There are 2 improvements to make watching for the k8s resources a lot faster (currently the app would have to wait for about 1-2 minutes before starting the watch functionality)

### Use prioritized list of APIs
In order to start polling for the resource sooner, before we get all resources we can pass in a list of APIs we want to query for first. This will put the prioritized APIs in the front and we'd still use batch requests not to break the API.

### Dispatch each resource to redux
Whenever we receive the resources from server we can emediately dispatch them to redux in order to unblock resource watching. So once the resource is in redux store the app can start watching for it.