### PR TITLE
Export all core extensions and add nav section type

### DIFF
--- a/packages/lib-core/src/extensions/navigations.ts
+++ b/packages/lib-core/src/extensions/navigations.ts
@@ -39,12 +39,21 @@ export type Separator = Extension<
   Omit<NavItemProperties, 'startsWith'>
 >;
 
+export type NavSection = Extension<
+  'core.navigation/section',
+  Omit<NavItemProperties, 'startsWith' | 'section'> & {
+    /** Name of this section. If not supplied, only a separator will be shown above the section. */
+    name?: string;
+  }
+>;
+
 // Type guards
 
 export const isHrefNavItem = (e: Extension): e is HrefNavItem => e.type === 'core.navigation/href';
 export const isResourceNSNavItem = (e: Extension): e is ResourceNSNavItem =>
   e.type === 'core.navigation/resource-ns';
 export const isSeparator = (e: Extension): e is Separator => e.type === 'core.navigation/separator';
+export const isNavSection = (e: Extension): e is NavSection => e.type === 'core.navigation/section';
 
 // Arbitrary types
 

--- a/packages/lib-core/src/index.ts
+++ b/packages/lib-core/src/index.ts
@@ -9,7 +9,7 @@ export {
 export { useExtensions } from './store/useExtensions';
 export { usePluginInfo } from './store/usePluginInfo';
 export { useResolvedExtensions } from './store/useResolvedExtensions';
-export { EncodedExtension } from './types/extension';
+export * from './types';
 
 // Core extension types, to be exported via lib-extensions package
 export * from './extensions';

--- a/packages/lib-core/src/types/index.ts
+++ b/packages/lib-core/src/types/index.ts
@@ -1,0 +1,5 @@
+export * from './common';
+export * from './extension';
+export * from './plugin';
+export * from './runtime';
+export * from './store';


### PR DESCRIPTION
### Export all core extensions

Since we want to allow apps to utilize fully all types we defined, let's export them.

### New navigation section

To fully support all navigation features we need to add nav section as well.