### PR TITLE
Enforce types - useK8sWatchResource and useK8sWatchResources

### DIFF
--- a/packages/lib-utils/src/k8s/hooks/useK8sWatchResource.ts
+++ b/packages/lib-utils/src/k8s/hooks/useK8sWatchResource.ts
@@ -30,7 +30,7 @@ const NOT_A_VALUE = '__not-a-value__';
  * ```
  */
 export const useK8sWatchResource = <R extends K8sResourceCommon | K8sResourceCommon[]>(
-  initResource: WatchK8sResource | null,
+  initResource: WatchK8sResource,
 ): WatchK8sResult<R> => {
   const cluster = useSelector<SDKStoreState, string>((state) => getActiveCluster(state));
   const withFallback: WatchK8sResource = initResource || { kind: NOT_A_VALUE };

--- a/packages/lib-utils/src/k8s/hooks/useK8sWatchResource.ts
+++ b/packages/lib-utils/src/k8s/hooks/useK8sWatchResource.ts
@@ -30,7 +30,7 @@ const NOT_A_VALUE = '__not-a-value__';
  * ```
  */
 export const useK8sWatchResource = <R extends K8sResourceCommon | K8sResourceCommon[]>(
-  initResource: WatchK8sResource,
+  initResource: WatchK8sResource | null,
 ): WatchK8sResult<R> => {
   const cluster = useSelector<SDKStoreState, string>((state) => getActiveCluster(state));
   const withFallback: WatchK8sResource = initResource || { kind: NOT_A_VALUE };

--- a/packages/lib-utils/src/k8s/hooks/watch-resource-types.ts
+++ b/packages/lib-utils/src/k8s/hooks/watch-resource-types.ts
@@ -7,13 +7,13 @@ import type {
 } from '../../types/k8s';
 
 export type WatchK8sResult<R extends K8sResourceCommon | K8sResourceCommon[]> = [
-  data: R | unknown,
+  data: R,
   loaded: boolean,
   loadError: unknown,
 ];
 
 export type WatchK8sResultsObject<R extends K8sResourceCommon | K8sResourceCommon[]> = {
-  data: R | unknown;
+  data: R;
   loaded: boolean;
   loadError: unknown;
 };


### PR DESCRIPTION
This is a follow-on to PR https://github.com/openshift/dynamic-plugin-sdk/pull/68 and addresses 2 review comments about ~enforcing the type on the input parameter to the useK8sWatchResource hook, see https://github.com/openshift/dynamic-plugin-sdk/pull/68#discussion_r857627499~  as well as on the return type WatchK8sResult, see https://github.com/openshift/dynamic-plugin-sdk/pull/68#discussion_r857639488