### PR TITLE
Bump lib-core version after publish

### DIFF
--- a/packages/lib-core/package.json
+++ b/packages/lib-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk",
-  "version": "1.0.0-alpha4",
+  "version": "1.0.0-alpha5",
   "description": "Allows loading, managing and interpreting dynamic plugins",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
`lib-core` got a new version published so bumping the version in repo as well.