### PR TITLE
Do not double encode query params

### DIFF
--- a/packages/lib-utils/src/k8s/k8s-utils.ts
+++ b/packages/lib-utils/src/k8s/k8s-utils.ts
@@ -171,14 +171,14 @@ export const k8sWatch = (
 
   const { labelSelector } = query;
   if (labelSelector) {
-    const encodedSelector = encodeURIComponent(selectorToString(labelSelector));
+    const encodedSelector = selectorToString(labelSelector);
     if (encodedSelector) {
       queryParams.labelSelector = encodedSelector;
     }
   }
 
   if (query.fieldSelector) {
-    queryParams.fieldSelector = encodeURIComponent(query.fieldSelector);
+    queryParams.fieldSelector = query.fieldSelector;
   }
 
   if (query.ns) {
@@ -186,7 +186,7 @@ export const k8sWatch = (
   }
 
   if (query.resourceVersion) {
-    queryParams.resourceVersion = encodeURIComponent(query.resourceVersion);
+    queryParams.resourceVersion = query.resourceVersion;
   }
 
   const path = getK8sResourceURL(kind, undefined, opts);


### PR DESCRIPTION
### Double encoding breaks WS connection

Since we are encoding URI component in `getK8sResourceURL` which is used when creating the WS URL we don't have to encode it again before calling this function in `k8sWatch` function.