### PR TITLE
[HAC-1295] Add basic feature flag support

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,5 +8,6 @@ yarnPath: .yarn/releases/yarn-3.2.0.cjs
 
 logFilters:
   # Suppress YN0060 (INCOMPATIBLE_PEER_DEPENDENCY) log messages for react-virtualized package
+  # Related issue: https://github.com/bvaughn/react-virtualized/pull/1740
   - pattern: "* provides react* with version *, which doesn't satisfy what react-virtualized requests"
     level: 'discard'

--- a/packages/lib-core/src/store/PluginStore.ts
+++ b/packages/lib-core/src/store/PluginStore.ts
@@ -224,7 +224,7 @@ export class PluginStore implements PluginConsumer, PluginManager {
    * @param {Extension} extension The extension to check for
    * @returns {boolean} returns `true` if the extension is in use, and `false` if it is not in use
    */
-  isExtensionInUse(extension: Extension) {
+  private isExtensionInUse(extension: Extension) {
     return (
       (extension.flags?.required?.every((f) => this.options.isFeatureFlagEnabled(f)) ?? true) &&
       (extension.flags?.disallowed?.every((f) => !this.options.isFeatureFlagEnabled(f)) ?? true)

--- a/packages/lib-core/src/store/PluginStore.ts
+++ b/packages/lib-core/src/store/PluginStore.ts
@@ -210,7 +210,8 @@ export class PluginStore implements PluginConsumer, PluginManager {
     const prevExtensions = this.extensions;
 
     this.extensions = Array.from(this.loadedPlugins.values()).reduce(
-      (acc, p) => (p.enabled ? [...acc, ...p.extensions.filter(this.isExtensionInUse)] : acc),
+      (acc, p) =>
+        p.enabled ? [...acc, ...p.extensions.filter(_.bind(this.isExtensionInUse, this))] : acc,
       [] as LoadedExtension[],
     );
 

--- a/packages/lib-core/src/store/PluginStore.ts
+++ b/packages/lib-core/src/store/PluginStore.ts
@@ -13,6 +13,8 @@ export type PluginStoreOptions = Partial<{
   autoEnableLoadedPlugins: boolean;
   /** Post-process loaded extension objects before adding associated plugin to the {@link PluginStore}. */
   postProcessExtensions: (extensions: LoadedExtension[]) => LoadedExtension[];
+  /** Determine whether the given feature flag is currently enabled. */
+  isFeatureFlagEnabled: (flag: string) => boolean;
 }>;
 
 /**
@@ -41,6 +43,7 @@ export class PluginStore implements PluginConsumer, PluginManager {
     this.options = {
       autoEnableLoadedPlugins: options.autoEnableLoadedPlugins ?? true,
       postProcessExtensions: options.postProcessExtensions ?? _.identity,
+      isFeatureFlagEnabled: options.isFeatureFlagEnabled ?? (() => false),
     };
 
     Object.values(PluginEventType).forEach((t) => {
@@ -114,11 +117,9 @@ export class PluginStore implements PluginConsumer, PluginManager {
     };
   }
 
-  private invokeListeners(eventTypes: PluginEventType[]) {
-    eventTypes.forEach((t) => {
-      this.listeners.get(t)?.forEach((listener) => {
-        listener();
-      });
+  private invokeListeners(eventType: PluginEventType) {
+    this.listeners.get(eventType)?.forEach((listener) => {
+      listener();
     });
   }
 
@@ -177,7 +178,7 @@ export class PluginStore implements PluginConsumer, PluginManager {
   }
 
   setPluginsEnabled(config: { pluginName: string; enabled: boolean }[]) {
-    let updateExtensions = false;
+    let update = false;
 
     config.forEach(({ pluginName, enabled }) => {
       if (!this.loadedPlugins.has(pluginName)) {
@@ -195,18 +196,34 @@ export class PluginStore implements PluginConsumer, PluginManager {
       if (plugin.enabled !== enabled) {
         plugin.enabled = enabled;
         consoleLogger.info(`Plugin ${pluginName} will be ${enabled ? 'enabled' : 'disabled'}`);
-        updateExtensions = true;
+        update = true;
       }
     });
 
-    if (updateExtensions) {
-      this.extensions = Array.from(this.loadedPlugins.values()).reduce(
-        (acc, p) => (p.enabled ? [...acc, ...p.extensions] : acc),
-        [] as LoadedExtension[],
-      );
-
-      this.invokeListeners([PluginEventType.PluginInfoChanged, PluginEventType.ExtensionsChanged]);
+    if (update) {
+      this.invokeListeners(PluginEventType.PluginInfoChanged);
+      this.updateExtensions();
     }
+  }
+
+  updateExtensions() {
+    const prevExtensions = this.extensions;
+
+    this.extensions = Array.from(this.loadedPlugins.values()).reduce(
+      (acc, p) => (p.enabled ? [...acc, ...p.extensions.filter(this.isExtensionInUse)] : acc),
+      [] as LoadedExtension[],
+    );
+
+    if (!_.isEqual(prevExtensions, this.extensions)) {
+      this.invokeListeners(PluginEventType.ExtensionsChanged);
+    }
+  }
+
+  isExtensionInUse(extension: Extension) {
+    return (
+      (extension.flags?.required?.every((f) => this.options.isFeatureFlagEnabled(f)) ?? true) &&
+      (extension.flags?.disallowed?.every((f) => !this.options.isFeatureFlagEnabled(f)) ?? true)
+    );
   }
 
   /**
@@ -232,7 +249,7 @@ export class PluginStore implements PluginConsumer, PluginManager {
     });
 
     this.failedPlugins.delete(pluginName);
-    this.invokeListeners([PluginEventType.PluginInfoChanged]);
+    this.invokeListeners(PluginEventType.PluginInfoChanged);
 
     consoleLogger.info(`Added plugin ${pluginName} version ${pluginVersion}`);
 
@@ -246,7 +263,7 @@ export class PluginStore implements PluginConsumer, PluginManager {
     }
 
     this.failedPlugins.add(pluginName);
-    this.invokeListeners([PluginEventType.PluginInfoChanged]);
+    this.invokeListeners(PluginEventType.PluginInfoChanged);
   }
 
   /**

--- a/packages/lib-core/src/store/PluginStore.ts
+++ b/packages/lib-core/src/store/PluginStore.ts
@@ -219,6 +219,11 @@ export class PluginStore implements PluginConsumer, PluginManager {
     }
   }
 
+  /**
+   * Checks whether an extension is in use based on the values of required and disallowed feature flags
+   * @param {Extension} extension The extension to check for
+   * @returns {boolean} returns `true` if the extension is in use, and `false` if it is not in use
+   */
   isExtensionInUse(extension: Extension) {
     return (
       (extension.flags?.required?.every((f) => this.options.isFeatureFlagEnabled(f)) ?? true) &&

--- a/packages/lib-core/src/store/PluginStore.ts
+++ b/packages/lib-core/src/store/PluginStore.ts
@@ -211,7 +211,7 @@ export class PluginStore implements PluginConsumer, PluginManager {
 
     this.extensions = Array.from(this.loadedPlugins.values()).reduce(
       (acc, p) =>
-        p.enabled ? [...acc, ...p.extensions.filter(_.bind(this.isExtensionInUse, this))] : acc,
+        p.enabled ? [...acc, ...p.extensions.filter((e) => this.isExtensionInUse(e))] : acc,
       [] as LoadedExtension[],
     );
 

--- a/packages/lib-core/src/types/extension.ts
+++ b/packages/lib-core/src/types/extension.ts
@@ -1,8 +1,14 @@
 import type { AnyObject, ReplaceProperties } from '@monorepo/common';
 
+type ExtensionFlags = Partial<{
+  required: string[];
+  disallowed: string[];
+}>;
+
 export type Extension<TType extends string = string, TProperties extends AnyObject = AnyObject> = {
   type: TType;
   properties: TProperties;
+  flags?: ExtensionFlags;
   [customProperty: string]: unknown;
 };
 

--- a/packages/lib-core/src/types/store.ts
+++ b/packages/lib-core/src/types/store.ts
@@ -81,4 +81,15 @@ export type PluginManager = {
    * Enabling a plugin puts all of its extensions into use. Disabling it does the opposite.
    */
   setPluginsEnabled: (config: { pluginName: string; enabled: boolean }[]) => void;
+
+  /**
+   * Update extensions which are currently in use.
+   *
+   * This function should be called whenever a change is detected in any feature flags that
+   * may be used by plugins to gate their extensions, including:
+   * - flags managed by the host application
+   * - flags contributed by plugins
+   * - flags managed by external services like Unleash
+   */
+  updateExtensions: () => void;
 };

--- a/packages/lib-core/src/yup-schemas.ts
+++ b/packages/lib-core/src/yup-schemas.ts
@@ -53,7 +53,7 @@ const extensionTypeSchema = yup
 const featureFlagNameSchema = yup
   .string()
   .required()
-  .matches(/^[A-Z]+[A-Z_]*$/, 'feature flag name');
+  .matches(/^[A-Z]+[A-Z0-9_]*$/, 'feature flag name');
 
 /**
  * Schema for `Extension` objects.

--- a/packages/lib-core/src/yup-schemas.ts
+++ b/packages/lib-core/src/yup-schemas.ts
@@ -42,12 +42,33 @@ const extensionTypeSchema = yup
   .matches(/^[a-z]+[a-z-]*\.[a-z]+[a-z-]*(?:\/[a-z]+[a-z-]*)*$/, 'extension type');
 
 /**
+ * Schema for a valid feature flag name.
+ *
+ * Examples:
+ *
+ * ```
+ * FOO, FOO_BAR
+ * ```
+ */
+const featureFlagNameSchema = yup
+  .string()
+  .required()
+  .matches(/^[A-Z]+[A-Z_]*$/, 'feature flag name');
+
+/**
  * Schema for `Extension` objects.
  */
-export const extensionSchema = yup.object().required().shape({
-  type: extensionTypeSchema,
-  properties: yup.object().required(),
-});
+export const extensionSchema = yup
+  .object()
+  .required()
+  .shape({
+    type: extensionTypeSchema,
+    properties: yup.object().required(),
+    flags: yup.object().shape({
+      required: yup.array().of(featureFlagNameSchema),
+      disallowed: yup.array().of(featureFlagNameSchema),
+    }),
+  });
 
 /**
  * Schema for an array of `Extension` objects.


### PR DESCRIPTION
This PR introduces support for feature flags in the Core SDK.

- Extensions will be able to specify feature flags within the optional `flags` attribute. (At the moment we are not distinguishing between flags that are app-specific and flags that may be managed by external services like Unleash.)
- The extensions in use will be determined based on the feature flags specified as `required` and `disallowed`.
- Consumer apps will need to implement the `isFeatureFlagEnabled` function (see `packages/lib-core/src/store/PluginStore.ts`). 
- The function `updateExtensions` should be called by the consumer app/plugin whenever a change is detected in any feature flags that may be used by plugins to gate their extensions. 
