### PR TITLE
API discovery fixes + removal of polling

### DIFF
--- a/packages/lib-utils/src/app/api-discovery/index.ts
+++ b/packages/lib-utils/src/app/api-discovery/index.ts
@@ -12,7 +12,7 @@ import type {
 import type { K8sModelCommon } from '../../types/k8s';
 import type { DispatchWithThunk } from '../../types/redux';
 import { commonFetchJSON } from '../../utils/common-fetch';
-import { getResourcesInFlight, receivedResources } from '../redux/actions/k8s';
+import { setResourcesInFlight, receivedResources } from '../redux/actions/k8s';
 import { cacheResources, getCachedResources } from './discovery-cache';
 
 const POLLs: { [id: string]: number } = {};
@@ -157,13 +157,15 @@ const getResources = async (
       dispatch(receivedResources(resource));
     });
   }
+  // Dispatch action to set inFlight to false
+  dispatch(setResourcesInFlight(false));
   return allResources.reduce((acc, curr) => _.merge(acc, curr));
 };
 
 const updateResources =
   (preferenceList: string[]) =>
   async (dispatch: Dispatch): Promise<DiscoveryResources> => {
-    dispatch(getResourcesInFlight());
+    dispatch(setResourcesInFlight(true));
 
     const resources = await getResources(preferenceList, dispatch);
     // // Cache the resources whenever discovery completes to improve console load times.

--- a/packages/lib-utils/src/app/api-discovery/index.ts
+++ b/packages/lib-utils/src/app/api-discovery/index.ts
@@ -15,9 +15,6 @@ import { commonFetchJSON } from '../../utils/common-fetch';
 import { setResourcesInFlight, setBatchesInFlight, receivedResources } from '../redux/actions/k8s';
 import { cacheResources, getCachedResources } from './discovery-cache';
 
-const POLLs: { [id: string]: number } = {};
-const apiDiscovery = 'apiDiscovery';
-const API_DISCOVERY_POLL_INTERVAL = 60_000;
 const API_DISCOVERY_INIT_DELAY = 5_000;
 const API_DISCOVERY_REQUEST_BATCH_SIZE = 5;
 
@@ -176,24 +173,12 @@ const updateResources =
   };
 
 const startAPIDiscovery = (preferenceList: string[]) => (dispatch: DispatchWithThunk) => {
-  consoleLogger.info(
-    `API discovery startAPIDiscovery: Polling every ${API_DISCOVERY_POLL_INTERVAL} ms`,
-  );
-  // Poll API discovery since we can't watch CRDs
   dispatch(updateResources(preferenceList))
     .then((resources) => {
-      if (POLLs[apiDiscovery]) {
-        clearTimeout(POLLs[apiDiscovery]);
-        delete POLLs[apiDiscovery];
-      }
-      POLLs[apiDiscovery] = window.setTimeout(
-        () => dispatch(startAPIDiscovery(preferenceList)),
-        API_DISCOVERY_POLL_INTERVAL,
-      );
       return resources;
     })
     // TODO handle failures - retry if error is recoverable
-    .catch((err) => consoleLogger.error('API discovery startAPIDiscovery polling failed:', err));
+    .catch((err) => consoleLogger.error('API discovery startAPIDiscovery failed:', err));
 };
 
 export const initAPIDiscovery: InitAPIDiscovery = (storeInstance, preferenceList = []) => {

--- a/packages/lib-utils/src/app/api-discovery/index.ts
+++ b/packages/lib-utils/src/app/api-discovery/index.ts
@@ -12,7 +12,7 @@ import type {
 import type { K8sModelCommon } from '../../types/k8s';
 import type { DispatchWithThunk } from '../../types/redux';
 import { commonFetchJSON } from '../../utils/common-fetch';
-import { setResourcesInFlight, receivedResources } from '../redux/actions/k8s';
+import { setResourcesInFlight, setBatchesInFlight, receivedResources } from '../redux/actions/k8s';
 import { cacheResources, getCachedResources } from './discovery-cache';
 
 const POLLs: { [id: string]: number } = {};
@@ -157,8 +157,8 @@ const getResources = async (
       dispatch(receivedResources(resource));
     });
   }
-  // Dispatch action to set inFlight to false
-  dispatch(setResourcesInFlight(false));
+  // Dispatch action to indicate all batches were loaded
+  dispatch(setBatchesInFlight(false));
   return allResources.reduce((acc, curr) => _.merge(acc, curr));
 };
 
@@ -166,6 +166,7 @@ const updateResources =
   (preferenceList: string[]) =>
   async (dispatch: Dispatch): Promise<DiscoveryResources> => {
     dispatch(setResourcesInFlight(true));
+    dispatch(setBatchesInFlight(true));
 
     const resources = await getResources(preferenceList, dispatch);
     // // Cache the resources whenever discovery completes to improve console load times.

--- a/packages/lib-utils/src/app/redux/actions/k8s.ts
+++ b/packages/lib-utils/src/app/redux/actions/k8s.ts
@@ -14,7 +14,7 @@ import type { WebSocketFactory } from '../../../web-socket/WebSocketFactory';
 
 export enum ActionType {
   ReceivedResources = 'resources',
-  GetResourcesInFlight = 'getResourcesInFlight',
+  SetResourcesInFlight = 'setResourcesInFlight',
   StartWatchK8sObject = 'startWatchK8sObject',
   StartWatchK8sList = 'startWatchK8sList',
   ModifyObject = 'modifyObject',
@@ -316,7 +316,8 @@ export const watchK8sObject =
 
 export const receivedResources = (resources: DiscoveryResources) =>
   action(ActionType.ReceivedResources, { resources });
-export const getResourcesInFlight = () => action(ActionType.GetResourcesInFlight);
+export const setResourcesInFlight = (inFlight: boolean) =>
+  action(ActionType.SetResourcesInFlight, { inFlight });
 
 const k8sActions = {
   startWatchK8sObject,
@@ -329,7 +330,7 @@ const k8sActions = {
   updateListFromWS,
   filterList,
   receivedResources,
-  getResourcesInFlight,
+  setResourcesInFlight,
 };
 
 export type K8sAction = Action<typeof k8sActions>;

--- a/packages/lib-utils/src/app/redux/actions/k8s.ts
+++ b/packages/lib-utils/src/app/redux/actions/k8s.ts
@@ -15,6 +15,7 @@ import type { WebSocketFactory } from '../../../web-socket/WebSocketFactory';
 export enum ActionType {
   ReceivedResources = 'resources',
   SetResourcesInFlight = 'setResourcesInFlight',
+  SetBatchesInFlight = 'setBatchesInFlight',
   StartWatchK8sObject = 'startWatchK8sObject',
   StartWatchK8sList = 'startWatchK8sList',
   ModifyObject = 'modifyObject',
@@ -318,6 +319,8 @@ export const receivedResources = (resources: DiscoveryResources) =>
   action(ActionType.ReceivedResources, { resources });
 export const setResourcesInFlight = (isInFlight: boolean) =>
   action(ActionType.SetResourcesInFlight, { isInFlight });
+export const setBatchesInFlight = (isInFlight: boolean) =>
+  action(ActionType.SetBatchesInFlight, { isInFlight });
 
 const k8sActions = {
   startWatchK8sObject,
@@ -331,6 +334,7 @@ const k8sActions = {
   filterList,
   receivedResources,
   setResourcesInFlight,
+  setBatchesInFlight,
 };
 
 export type K8sAction = Action<typeof k8sActions>;

--- a/packages/lib-utils/src/app/redux/actions/k8s.ts
+++ b/packages/lib-utils/src/app/redux/actions/k8s.ts
@@ -316,8 +316,8 @@ export const watchK8sObject =
 
 export const receivedResources = (resources: DiscoveryResources) =>
   action(ActionType.ReceivedResources, { resources });
-export const setResourcesInFlight = (inFlight: boolean) =>
-  action(ActionType.SetResourcesInFlight, { inFlight });
+export const setResourcesInFlight = (isInFlight: boolean) =>
+  action(ActionType.SetResourcesInFlight, { isInFlight });
 
 const k8sActions = {
   startWatchK8sObject,

--- a/packages/lib-utils/src/app/redux/reducers/k8s/k8s.ts
+++ b/packages/lib-utils/src/app/redux/reducers/k8s/k8s.ts
@@ -98,6 +98,9 @@ export const sdkK8sReducer = (state: K8sState, action: K8sAction): K8sState => {
     case ActionType.SetResourcesInFlight:
       return state.setIn(['RESOURCES', 'inFlight'], action.payload.isInFlight);
 
+    case ActionType.SetBatchesInFlight:
+      return state.setIn(['RESOURCES', 'batchesInFlight'], action.payload.isInFlight);
+
     case ActionType.ReceivedResources:
       return (
         action.payload.resources.models
@@ -146,6 +149,7 @@ export const sdkK8sReducer = (state: K8sState, action: K8sAction): K8sState => {
           )
           .setIn(['RESOURCES', 'namespacedSet'], action.payload.resources.namespacedSet)
           .setIn(['RESOURCES', 'groupToVersionMap'], action.payload.resources.groupVersionMap)
+          .setIn(['RESOURCES', 'inFlight'], false)
       );
 
     case ActionType.StartWatchK8sObject:

--- a/packages/lib-utils/src/app/redux/reducers/k8s/k8s.ts
+++ b/packages/lib-utils/src/app/redux/reducers/k8s/k8s.ts
@@ -95,8 +95,8 @@ export const sdkK8sReducer = (state: K8sState, action: K8sAction): K8sState => {
 
   let newList;
   switch (action.type) {
-    case ActionType.GetResourcesInFlight:
-      return state.setIn(['RESOURCES', 'inFlight'], true);
+    case ActionType.SetResourcesInFlight:
+      return state.setIn(['RESOURCES', 'inFlight'], action.payload.inFlight);
 
     case ActionType.ReceivedResources:
       return (
@@ -146,7 +146,6 @@ export const sdkK8sReducer = (state: K8sState, action: K8sAction): K8sState => {
           )
           .setIn(['RESOURCES', 'namespacedSet'], action.payload.resources.namespacedSet)
           .setIn(['RESOURCES', 'groupToVersionMap'], action.payload.resources.groupVersionMap)
-          .setIn(['RESOURCES', 'inFlight'], false)
       );
 
     case ActionType.StartWatchK8sObject:

--- a/packages/lib-utils/src/app/redux/reducers/k8s/k8s.ts
+++ b/packages/lib-utils/src/app/redux/reducers/k8s/k8s.ts
@@ -96,7 +96,7 @@ export const sdkK8sReducer = (state: K8sState, action: K8sAction): K8sState => {
   let newList;
   switch (action.type) {
     case ActionType.SetResourcesInFlight:
-      return state.setIn(['RESOURCES', 'inFlight'], action.payload.inFlight);
+      return state.setIn(['RESOURCES', 'inFlight'], action.payload.isInFlight);
 
     case ActionType.ReceivedResources:
       return (

--- a/packages/lib-utils/src/k8s/hooks/useK8sWatchResource.test.ts
+++ b/packages/lib-utils/src/k8s/hooks/useK8sWatchResource.test.ts
@@ -107,8 +107,20 @@ describe('useK8sWatchResource', () => {
     useDeepCompareMemoizeMock.mockReturnValue(watchedResourceMock);
 
     const { result } = renderHook(() => useK8sWatchResource(watchedResourceMock));
-    const [data, loaded, error] = result.current;
+    let [data, loaded, error] = result.current;
 
+    expect(data).toMatchObject({});
+    expect(loaded).toEqual(false);
+    expect(error).toBeUndefined();
+
+    // When an initial batch of models have loaded but not all batches
+    useModelsLoadedMock.mockReturnValue(true);
+    useSelectorMock
+      .mockReturnValueOnce(null) // get resourceK8s
+      .mockReturnValueOnce(true); // batchesInFlight: true to indicate all batches of resources have loaded
+
+    const checkAllBatches = renderHook(() => useK8sWatchResource(watchedResourceMock));
+    [data, loaded, error] = checkAllBatches.result.current;
     expect(data).toMatchObject({});
     expect(loaded).toEqual(false);
     expect(error).toBeUndefined();
@@ -116,6 +128,9 @@ describe('useK8sWatchResource', () => {
 
   test('should return specific error if the model for the watched resource does not exist', () => {
     useDeepCompareMemoizeMock.mockReturnValue(watchedResourceMock);
+    useSelectorMock
+      .mockReturnValueOnce(null) // get resourceK8s
+      .mockReturnValueOnce(false); // batchesInFlight: true to indicate all batches of resources have loaded
 
     const { result } = renderHook(() => useK8sWatchResource(watchedResourceMock));
     const [data, loaded, error] = result.current;

--- a/packages/lib-utils/src/k8s/hooks/useK8sWatchResource.test.ts
+++ b/packages/lib-utils/src/k8s/hooks/useK8sWatchResource.test.ts
@@ -113,11 +113,11 @@ describe('useK8sWatchResource', () => {
     expect(loaded).toEqual(false);
     expect(error).toBeUndefined();
 
-    // When an initial batch of models have loaded but not all batches
+    // When an initial batch of models has loaded
     useModelsLoadedMock.mockReturnValue(true);
     useSelectorMock
       .mockReturnValueOnce(null) // get resourceK8s
-      .mockReturnValueOnce(true); // batchesInFlight: true to indicate all batches of resources have loaded
+      .mockReturnValueOnce(true); // batchesInFlight: true to indicate that some batches of resources are still loading
 
     const checkAllBatches = renderHook(() => useK8sWatchResource(watchedResourceMock));
     [data, loaded, error] = checkAllBatches.result.current;
@@ -130,7 +130,7 @@ describe('useK8sWatchResource', () => {
     useDeepCompareMemoizeMock.mockReturnValue(watchedResourceMock);
     useSelectorMock
       .mockReturnValueOnce(null) // get resourceK8s
-      .mockReturnValueOnce(false); // batchesInFlight: true to indicate all batches of resources have loaded
+      .mockReturnValueOnce(false); // batchesInFlight: true to indicate that some batches of resources are still loading
 
     const { result } = renderHook(() => useK8sWatchResource(watchedResourceMock));
     const [data, loaded, error] = result.current;

--- a/packages/lib-utils/src/k8s/hooks/useK8sWatchResource.ts
+++ b/packages/lib-utils/src/k8s/hooks/useK8sWatchResource.ts
@@ -56,13 +56,17 @@ export const useK8sWatchResource = <R extends K8sResourceCommon | K8sResourceCom
     watchData ? getReduxIdPayload(state, watchData.id) : null,
   ) as ImmutableMap<string, unknown>; // TODO: Store state based off of Immutable is problematic
 
+  const batchesInFlight = useSelector<SDKStoreState, boolean>(({ k8s }) =>
+    k8s?.getIn(['RESOURCES', 'batchesInFlight']),
+  );
+
   return React.useMemo(() => {
     if (!resource || resource.kind === NOT_A_VALUE) {
       return [undefined, true, undefined];
     }
     if (!resourceK8s) {
       const data = resource.isList ? [] : {};
-      return modelsLoaded && !k8sModel
+      return modelsLoaded && !k8sModel && !batchesInFlight
         ? [data, true, new NoModelError()]
         : [data, false, undefined];
     }
@@ -71,5 +75,5 @@ export const useK8sWatchResource = <R extends K8sResourceCommon | K8sResourceCom
     const loaded = resourceK8s.get('loaded') as boolean;
     const loadError = resourceK8s.get('loadError');
     return [data, loaded, loadError];
-  }, [resource, resourceK8s, modelsLoaded, k8sModel]);
+  }, [resource, resourceK8s, modelsLoaded, k8sModel, batchesInFlight]);
 };

--- a/packages/lib-utils/src/k8s/hooks/useK8sWatchResources.test.ts
+++ b/packages/lib-utils/src/k8s/hooks/useK8sWatchResources.test.ts
@@ -101,12 +101,12 @@ describe('useK8sWatchResources', () => {
     expect(loaded).toEqual(false);
     expect(loadError).toBeUndefined();
 
-    // When an initial batch of models have loaded but not all batches
+    // When an initial batch of models has loaded
     useModelsLoadedMock.mockReturnValue(true);
     useSelectorMock
       .mockReturnValueOnce(ImmutableMap<string, K8sModelCommon>()) // get resourceK8s
       .mockReturnValueOnce(ImmutableMap<string, unknown>())
-      .mockReturnValueOnce(true); // batchesInFlight: true to indicate all batches of resources have loaded
+      .mockReturnValueOnce(true); // batchesInFlight: true to indicate that some batches of resources are still loading
 
     const checkAllBatches = renderHook(() => useK8sWatchResources(watchedResourcesMock));
     const resultingApp = checkAllBatches.result.current.application;

--- a/packages/lib-utils/src/k8s/hooks/useK8sWatchResources.ts
+++ b/packages/lib-utils/src/k8s/hooks/useK8sWatchResources.ts
@@ -148,11 +148,15 @@ export const useK8sWatchResources = <R extends ResourcesObject>(
 
   const resourceK8s = useSelector((state: SDKStoreState) => state.k8s, resourceK8sSelectorCreator);
 
+  const batchesInFlight = useSelector<SDKStoreState, boolean>(({ k8s }) =>
+    k8s?.getIn(['RESOURCES', 'batchesInFlight']),
+  );
+
   const results = React.useMemo(
     () =>
       Object.keys(resources).reduce<WatchK8sResults<R>>((acc, key) => {
         const accKey = key as keyof R;
-        if (reduxIDs?.[key].noModel) {
+        if (reduxIDs?.[key].noModel && !batchesInFlight) {
           acc[accKey] = {
             data: resources[key].isList ? [] : {},
             loaded: true,
@@ -172,7 +176,7 @@ export const useK8sWatchResources = <R extends ResourcesObject>(
         }
         return acc;
       }, {} as WatchK8sResults<R>),
-    [resources, reduxIDs, resourceK8s],
+    [resources, reduxIDs, resourceK8s, batchesInFlight],
   );
   return results;
 };


### PR DESCRIPTION
This PR addresses the issue reported with the useK8sWatchResource hook returning `loaded: true` prematurely before a resource has finished loading. See conversation [here](https://coreos.slack.com/archives/C02EQERSV3N/p1652880898987469).

The proposed solution is described [here](https://docs.google.com/document/d/1QEiVhO0LiUamKJxmV-CWJZXjCzR13yFc6_mER2-6d34/edit?usp=sharing).

Conversation related to removal of polling [here](https://coreos.slack.com/archives/C02EQERSV3N/p1651248544636789).