### PR TITLE
add core.redux-provider extension and support

### DIFF
--- a/packages/lib-core/src/extensions/redux.ts
+++ b/packages/lib-core/src/extensions/redux.ts
@@ -1,7 +1,12 @@
-import type { Reducer } from 'redux';
+import type { ReactReduxContextValue } from 'react-redux';
+import type { Reducer, Store } from 'redux';
 import type { CodeRef, Extension } from '../types/extension';
 
-/** Adds new reducer to host application's Redux store which operates on `plugins.<scope>` substate. */
+/**
+ * Adds new reducer to host application's Redux store which operates on `plugins.<scope>` substate.
+ *
+ * @deprecated use the `core.redux-provider` extension instead
+ */
 export type ReduxReducer = Extension<
   'core.redux-reducer',
   {
@@ -12,6 +17,23 @@ export type ReduxReducer = Extension<
   }
 >;
 
+/** Provides a configuration for establishing new Redux store instance scoped to the contributing plugin.  */
+export type ReduxProvider = Extension<
+  'core.redux-provider',
+  {
+    /** The configured Redux store object; configured with reducers, middleware, etc... */
+    store: CodeRef<Store>;
+    /** The Redux React context object for which the instance will be scoped to. */
+    context: CodeRef<React.Context<ReactReduxContextValue>>;
+  }
+>;
+
 // Type guards
 
+/**
+ * @deprecated use the `core.redux-provider` extension instead
+ */
 export const isReduxReducer = (e: Extension): e is ReduxReducer => e.type === 'core.redux-reducer';
+
+export const isReduxProvider = (e: Extension): e is ReduxProvider =>
+  e.type === 'core.redux-reducer';

--- a/packages/lib-utils/src/app/redux/ReduxExtensionProvider.test.tsx
+++ b/packages/lib-utils/src/app/redux/ReduxExtensionProvider.test.tsx
@@ -1,0 +1,118 @@
+import type {
+  ReduxProvider,
+  ResolvedExtension,
+  LoadedExtension,
+} from '@openshift/dynamic-plugin-sdk';
+import { useResolvedExtensions } from '@openshift/dynamic-plugin-sdk';
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import type { ReactReduxContextValue } from 'react-redux';
+import { createSelectorHook } from 'react-redux';
+import type { Store } from 'redux';
+import { createStore } from 'redux';
+import ReduxExtensionProvider from './ReduxExtensionProvider';
+
+type LRReduxReducer = LoadedExtension<ResolvedExtension<ReduxProvider>>;
+
+jest.mock('@openshift/dynamic-plugin-sdk', () => ({
+  useResolvedExtensions: jest.fn(),
+}));
+
+const useResolvedExtensionsMock = jest.mocked(useResolvedExtensions, false);
+
+describe('ReduxExtensionProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should register multiple providers with separate redux contexts', () => {
+    type State = {
+      value: number;
+    };
+
+    const store1: Store = createStore((state) => state ?? { value: 1 });
+    const store2: Store = createStore((state) => state ?? { value: 2 });
+
+    // create 2 core.redux-provider extensions
+    const extensions: LRReduxReducer[] = [
+      {
+        uid: '1',
+        pluginName: 'test',
+        type: 'core.redux-provider',
+        properties: {
+          store: store1,
+          context: React.createContext<ReactReduxContextValue>({
+            store: store1,
+            storeState: store1.getState(),
+          }),
+        },
+      },
+      {
+        uid: '2',
+        pluginName: 'test',
+        type: 'core.redux-provider',
+        properties: {
+          store: store2,
+          context: React.createContext<ReactReduxContextValue>({
+            store: store2,
+            storeState: store2.getState(),
+          }),
+        },
+      },
+    ];
+
+    // mock that returns the test extensions
+    useResolvedExtensionsMock.mockReturnValue([extensions, true, []]);
+
+    // create 2 contextual redux selectors; one for each extension
+    const useSelector1 = createSelectorHook<State>(extensions[0].properties.context);
+    const useSelector2 = createSelectorHook<State>(extensions[1].properties.context);
+
+    let value1 = -1;
+    let value2 = -1;
+
+    // this component will select values separately from each redux store
+    const Test: React.FC = () => {
+      value1 = useSelector1((state) => state.value);
+      value2 = useSelector2((state) => state.value);
+      return null;
+    };
+
+    render(
+      <ReduxExtensionProvider>
+        <Test />
+      </ReduxExtensionProvider>,
+    );
+
+    // assert that the values received by each selector relate to their corresponding redux state
+    expect(value1).toBe(1);
+    expect(value2).toBe(2);
+  });
+
+  test('should render children', () => {
+    // mock return value of empty set of extensions
+    useResolvedExtensionsMock.mockReturnValue([[], true, []]);
+
+    const { container } = render(
+      <ReduxExtensionProvider>
+        <span id="test" />
+      </ReduxExtensionProvider>,
+    );
+
+    expect(container.firstElementChild?.tagName).toBe('SPAN');
+    expect(container.firstElementChild?.getAttribute('id')).toBe('test');
+  });
+
+  test('should return null if extensions are unresolved', () => {
+    // mock return value of empty set of extensions
+    useResolvedExtensionsMock.mockReturnValue([[], false, []]);
+
+    const { container } = render(
+      <ReduxExtensionProvider>
+        <span id="test" />
+      </ReduxExtensionProvider>,
+    );
+
+    expect(container.firstElementChild).toBe(null);
+  });
+});

--- a/packages/lib-utils/src/app/redux/ReduxExtensionProvider.tsx
+++ b/packages/lib-utils/src/app/redux/ReduxExtensionProvider.tsx
@@ -1,0 +1,28 @@
+import { useResolvedExtensions, isReduxProvider } from '@openshift/dynamic-plugin-sdk';
+import type { ReduxProvider } from '@openshift/dynamic-plugin-sdk';
+import * as React from 'react';
+import { Provider } from 'react-redux';
+
+/**
+ * Renders a Redux.Provider for each `core.redux-provider` extension.
+ * Should be rendered near the root of the application.
+ */
+const ReduxExtensionProvider: React.FC = ({ children }) => {
+  const [reduxProviderExtensions, reduxProvidersResolved] =
+    useResolvedExtensions<ReduxProvider>(isReduxProvider);
+
+  return reduxProvidersResolved ? (
+    <>
+      {reduxProviderExtensions.reduce(
+        (c, e) => (
+          <Provider store={e.properties.store} context={e.properties.context}>
+            {c}
+          </Provider>
+        ),
+        children,
+      )}
+    </>
+  ) : null;
+};
+
+export default ReduxExtensionProvider;

--- a/packages/lib-utils/src/index.ts
+++ b/packages/lib-utils/src/index.ts
@@ -1,5 +1,6 @@
 export { default as AppInitSDK } from './app/AppInitSDK';
 export { SDKReducers } from './app/redux/reducers';
+export { default as ReduxExtensionProvider } from './app/redux/ReduxExtensionProvider';
 export { UtilsConfig, isUtilsConfigSet, setUtilsConfig, getUtilsConfig } from './config';
 export { commonFetch, commonFetchText, commonFetchJSON } from './utils/common-fetch';
 export { useK8sWatchResource, useK8sWatchResources } from './k8s/hooks';


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/HAC-1296

New extension `core.redux-provider`.
Provides a configuration for establishing a Redux instance scoped for the contributing plugin.

`ReduxExtensionProvider` component may be used by applications to support redux providers at the root.

Each redux provider will be scoped by the extension with a unique store and context.

Usage of redux apis must supply the context to gain access to the respective store. eg `createSelectorHook(myContext);`