### PR TITLE
Export TableView from lib-utils so it can be accessed from hac-infra

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "rollup": "^2.61.1",
     "rollup-plugin-analyzer": "^4.0.0",
     "rollup-plugin-dts": "^4.0.1",
+    "rollup-plugin-import-css": "^3.0.3",
     "start-server-and-test": "^1.14.0",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.7.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/react": "^17.0.43",
     "@types/react-dom": "^17.0.14",
     "@types/react-router": "^5.1.17",
+    "@types/react-router-dom": "^5.3.3",
     "@types/react-virtualized": "^9.21.21",
     "@typescript-eslint/eslint-plugin": "^5.3.1",
     "@typescript-eslint/parser": "^5.3.1",

--- a/packages/common/rollup-configs.js
+++ b/packages/common/rollup-configs.js
@@ -4,6 +4,7 @@ import nodeResolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import analyzer from 'rollup-plugin-analyzer';
 import dts from 'rollup-plugin-dts';
+import css from 'rollup-plugin-import-css';
 
 // https://yarnpkg.com/advanced/lifecycle-scripts#environment-variables
 const rootDir = process.env.PROJECT_CWD;
@@ -65,6 +66,7 @@ export const tsLibConfig = (pkg, inputFile, format = 'esm') => ({
   plugins: [
     nodeResolve(),
     commonjs(),
+    css(),
     typescript({
       tsconfig: './tsconfig.json',
       include: ['src/**/*', '../common/src/**/*'],

--- a/packages/common/rollup-configs.js
+++ b/packages/common/rollup-configs.js
@@ -15,10 +15,9 @@ const getExternalModules = (pkg) => [
   ...('lodash' in pkg.dependencies ? ['lodash-es'] : []),
 ];
 
-const getExternalModuleTester = (pkg) => {
+const getExternalModuleRegExps = (pkg) => {
   const externalModules = getExternalModules(pkg);
-  const externalModuleTests = externalModules.map((module) => new RegExp(`^${module}(\\/.+)*$`));
-  return (moduleID) => externalModuleTests.some((regexp) => regexp.test(moduleID));
+  return externalModules.map((module) => new RegExp(`^${module}(\\/.+)*$`));
 };
 
 const getBanner = (pkg) => {
@@ -62,11 +61,13 @@ export const tsLibConfig = (pkg, inputFile, format = 'esm') => ({
     format,
     banner: getBanner(pkg),
   },
-  external: getExternalModuleTester(pkg),
+  external: getExternalModuleRegExps(pkg),
   plugins: [
     nodeResolve(),
     commonjs(),
-    css(),
+    css({
+      output: 'dist/index.css',
+    }),
     typescript({
       tsconfig: './tsconfig.json',
       include: ['src/**/*', '../common/src/**/*'],
@@ -90,7 +91,7 @@ export const dtsLibConfig = (pkg, inputFile) => ({
   output: {
     file: 'dist/index.d.ts',
   },
-  external: getExternalModuleTester(pkg),
+  external: [...getExternalModuleRegExps(pkg), /\.css$/],
   plugins: [
     dts({
       respectExternal: true,

--- a/packages/lib-utils/src/app/redux/index.ts
+++ b/packages/lib-utils/src/app/redux/index.ts
@@ -46,7 +46,7 @@ export const useReduxStore = (): UseReduxStoreResult => {
         {},
         compose(applyMiddleware(thunk)),
       );
-      setReduxStore(storeInstance);
+      setReduxStore(storeInstance as unknown as Store);
     }
     return getReduxStore();
   }, [storeContext]);

--- a/packages/lib-utils/src/components/table-view/TableView.tsx
+++ b/packages/lib-utils/src/components/table-view/TableView.tsx
@@ -9,7 +9,7 @@ import {
   ToolbarItemVariant,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 import * as React from 'react';
 import { useSearchParams, useLocation } from 'react-router-dom';
 import { parseFiltersFromURL, setFiltersToURL } from '../../utils/url-sync';

--- a/packages/lib-utils/src/components/table-view/index.ts
+++ b/packages/lib-utils/src/components/table-view/index.ts
@@ -1,0 +1,1 @@
+export { default as TableView, FilterItem, TableViewProps } from './TableView';

--- a/packages/lib-utils/src/components/table/VirtualizedTable.tsx
+++ b/packages/lib-utils/src/components/table/VirtualizedTable.tsx
@@ -1,7 +1,7 @@
 import type { AnyObject } from '@monorepo/common';
 import { Th, Thead, Tr, TableComposable } from '@patternfly/react-table';
 import { AutoSizer, WindowScroller } from '@patternfly/react-virtualized-extension';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import * as React from 'react';
 import type { Size, WindowScrollerChildProps } from 'react-virtualized';
 import type { LoadError } from '../status/StatusBox';

--- a/packages/lib-utils/src/index.ts
+++ b/packages/lib-utils/src/index.ts
@@ -4,6 +4,7 @@ export { default as ReduxExtensionProvider } from './app/redux/ReduxExtensionPro
 export { UtilsConfig, isUtilsConfigSet, setUtilsConfig, getUtilsConfig } from './config';
 export { commonFetch, commonFetchText, commonFetchJSON } from './utils/common-fetch';
 export { useK8sWatchResource, useK8sWatchResources, useK8sModel, useK8sModels } from './k8s/hooks';
+export { TableView, FilterItem, TableViewProps } from './components/table-view';
 export {
   WatchK8sResource,
   WatchK8sResources,

--- a/yarn.lock
+++ b/yarn.lock
@@ -924,6 +924,7 @@ __metadata:
     "@types/react": ^17.0.43
     "@types/react-dom": ^17.0.14
     "@types/react-router": ^5.1.17
+    "@types/react-router-dom": ^5.3.3
     "@types/react-virtualized": ^9.21.21
     "@typescript-eslint/eslint-plugin": ^5.3.1
     "@typescript-eslint/parser": ^5.3.1
@@ -1781,7 +1782,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-router@npm:^5.1.17":
+"@types/react-router-dom@npm:^5.3.3":
+  version: 5.3.3
+  resolution: "@types/react-router-dom@npm:5.3.3"
+  dependencies:
+    "@types/history": ^4.7.11
+    "@types/react": "*"
+    "@types/react-router": "*"
+  checksum: 28c4ea48909803c414bf5a08502acbb8ba414669b4b43bb51297c05fe5addc4df0b8fd00e0a9d1e3535ec4073ef38aaafac2c4a2b95b787167d113bc059beff3
+  languageName: node
+  linkType: hard
+
+"@types/react-router@npm:*, @types/react-router@npm:^5.1.17":
   version: 5.1.18
   resolution: "@types/react-router@npm:5.1.18"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,6 +956,7 @@ __metadata:
     rollup: ^2.61.1
     rollup-plugin-analyzer: ^4.0.0
     rollup-plugin-dts: ^4.0.1
+    rollup-plugin-import-css: ^3.0.3
     start-server-and-test: ^1.14.0
     ts-jest: ^27.1.4
     ts-node: ^10.7.0
@@ -1346,6 +1347,16 @@ __metadata:
   peerDependencies:
     rollup: ^1.20.0||^2.0.0
   checksum: 8be16e27863c219edbb25a4e6ec2fe0e1e451d9e917b6a43cf2ae5bc025a6b8faaa40f82a6e53b66d0de37b58ff472c6c3d57a83037ae635041f8df959d6d9aa
+  languageName: node
+  linkType: hard
+
+"@rollup/pluginutils@npm:^4.2.0":
+  version: 4.2.1
+  resolution: "@rollup/pluginutils@npm:4.2.1"
+  dependencies:
+    estree-walker: ^2.0.1
+    picomatch: ^2.2.2
+  checksum: 6bc41f22b1a0f1efec3043899e4d3b6b1497b3dea4d94292d8f83b4cf07a1073ecbaedd562a22d11913ff7659f459677b01b09e9598a98936e746780ecc93a12
   languageName: node
   linkType: hard
 
@@ -8724,6 +8735,17 @@ __metadata:
     "@babel/code-frame":
       optional: true
   checksum: e18165c7722909af0227ba0752062eea4fc26e5a465d95c2ad52426e376de57dcf3a966b1e4395a7e8d4f203cb148cd88da85d515332eb87b0f6fbd0f3feb2b7
+  languageName: node
+  linkType: hard
+
+"rollup-plugin-import-css@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "rollup-plugin-import-css@npm:3.0.3"
+  dependencies:
+    "@rollup/pluginutils": ^4.2.0
+  peerDependencies:
+    rollup: ^2.x.x
+  checksum: 73e7308054dd5564be6a370b5643b82ddf4b60ae2c4e27edce94ae057ef86e2a5474b7fb63d89f34b973416e2aae219917b189e5556958e2131302a28c6018d1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR exposes the TableView component from lib-utils.

But since this component utilizes css from `lib-utils/src/table-vietable-view.css` the CSS imports need to be processed for the build.
