### PR TITLE
Add support for only one filter

### DIFF
--- a/packages/eslint-plugin-internal/src/rules/react-typescript-prettier.js
+++ b/packages/eslint-plugin-internal/src/rules/react-typescript-prettier.js
@@ -13,4 +13,7 @@ module.exports = {
 
   // Enforce a defaultProps definition for every prop that is not a required prop
   'react/require-default-props': 'off',
+
+  // Enforce that block statements are wrapped in curly braces
+  curly: ['error', 'all'],
 };

--- a/packages/lib-utils/src/components/list-view/ListView.tsx
+++ b/packages/lib-utils/src/components/list-view/ListView.tsx
@@ -87,25 +87,27 @@ const ListView: React.FC<ListViewProps<Record<string, unknown>>> = ({
         <ToolbarContent>
           {filters ? (
             <>
-              <ToolbarItem key="filter-select">
-                <Select
-                  toggleIcon={<FilterIcon />}
-                  variant={SelectVariant.single}
-                  onToggle={(value) => setFilterSelectExpanded(value)}
-                  onSelect={(e, selection) => {
-                    setActiveFilter(filters.find((item) => item.id === selection));
-                    setFilterSelectExpanded(false);
-                  }}
-                  placeholderText={activeFilter?.label}
-                  isOpen={isFilterSelectExpanded}
-                >
-                  {filters.map((option) => (
-                    <SelectOption key={option.id} value={option.id}>
-                      {option.label}
-                    </SelectOption>
-                  ))}
-                </Select>
-              </ToolbarItem>
+              {filters.length > 1 && (
+                <ToolbarItem key="filter-select">
+                  <Select
+                    toggleIcon={<FilterIcon />}
+                    variant={SelectVariant.single}
+                    onToggle={(value) => setFilterSelectExpanded(value)}
+                    onSelect={(e, selection) => {
+                      setActiveFilter(filters.find((item) => item.id === selection));
+                      setFilterSelectExpanded(false);
+                    }}
+                    placeholderText={activeFilter?.label}
+                    isOpen={isFilterSelectExpanded}
+                  >
+                    {filters.map((option) => (
+                      <SelectOption key={option.id} value={option.id}>
+                        {option.label}
+                      </SelectOption>
+                    ))}
+                  </Select>
+                </ToolbarItem>
+              )}
               <ToolbarItem variant={ToolbarItemVariant['search-filter']} key="search-filter">
                 <SearchInput
                   className="dps-list-view__search"
@@ -124,7 +126,7 @@ const ListView: React.FC<ListViewProps<Record<string, unknown>>> = ({
                     }
                   }}
                   value={activeFilter ? filterValues.current[activeFilter.id]?.[0] : ''}
-                  placeholder={`Filter by ${activeFilter?.label}`}
+                  placeholder={`Search by ${activeFilter?.label}`}
                 />
               </ToolbarItem>
             </>

--- a/packages/lib-utils/src/components/list-view/ListView.tsx
+++ b/packages/lib-utils/src/components/list-view/ListView.tsx
@@ -126,7 +126,7 @@ const ListView: React.FC<ListViewProps<Record<string, unknown>>> = ({
                     }
                   }}
                   value={activeFilter ? filterValues.current[activeFilter.id]?.[0] : ''}
-                  placeholder={`Search by ${activeFilter?.label}`}
+                  placeholder={activeFilter?.label ? `Search by ${activeFilter.label}` : 'Search'}
                 />
               </ToolbarItem>
             </>

--- a/packages/lib-utils/src/components/list-view/list-view.css
+++ b/packages/lib-utils/src/components/list-view/list-view.css
@@ -2,6 +2,10 @@
   margin-right: var(--pf-global--spacer--sm);
 }
 
+.pf-c-search-input__text-input {
+  outline: none;
+}
+
 .pf-c-toolbar__item.dps-list-view__top-pagination {
   margin-left: auto;
 }

--- a/packages/lib-utils/src/k8s/k8s-utils.ts
+++ b/packages/lib-utils/src/k8s/k8s-utils.ts
@@ -267,7 +267,9 @@ export const getGroupVersionKindForReference = (
   reference: K8sResourceKindReference,
 ): K8sGroupVersionKind => {
   const referenceSplit = reference.split('~');
-  if (referenceSplit.length > 3) throw new Error('Provided reference is invalid.');
+  if (referenceSplit.length > 3) {
+    throw new Error('Provided reference is invalid.');
+  }
 
   const [group, version, kind] = referenceSplit;
   return {


### PR DESCRIPTION
https://issues.redhat.com/browse/HAC-1721

When there is only one filter defined, filter selection disappears and only text input is visible.
![onlysearch](https://user-images.githubusercontent.com/50696716/177765040-edf64645-5f55-439d-8b9c-4ef326f746d4.png)

@florkbr not sure about the search icon - this is what PF search input looks like by default. Do we want to have the search icon on the right as in the mocks? Should it work as a submit button?
