### PR TITLE
Export useK8sModel hook and its type

### DIFF
--- a/packages/lib-utils/src/index.ts
+++ b/packages/lib-utils/src/index.ts
@@ -3,7 +3,7 @@ export { SDKReducers } from './app/redux/reducers';
 export { default as ReduxExtensionProvider } from './app/redux/ReduxExtensionProvider';
 export { UtilsConfig, isUtilsConfigSet, setUtilsConfig, getUtilsConfig } from './config';
 export { commonFetch, commonFetchText, commonFetchJSON } from './utils/common-fetch';
-export { useK8sWatchResource, useK8sWatchResources } from './k8s/hooks';
+export { useK8sWatchResource, useK8sWatchResources, useK8sModel, useK8sModels } from './k8s/hooks';
 export {
   WatchK8sResource,
   WatchK8sResources,
@@ -11,6 +11,7 @@ export {
   WatchK8sResult,
   WatchK8sResultsObject,
 } from './k8s/hooks/watch-resource-types';
+export { UseK8sModel, UseK8sModels } from './k8s/hooks/use-model-types';
 export {
   k8sGetResource,
   k8sCreateResource,

--- a/packages/lib-utils/src/k8s/hooks/index.ts
+++ b/packages/lib-utils/src/k8s/hooks/index.ts
@@ -1,2 +1,4 @@
 export { useK8sWatchResource } from './useK8sWatchResource';
 export { useK8sWatchResources } from './useK8sWatchResources';
+export { useK8sModel } from './useK8sModel';
+export { useK8sModels } from './useK8sModels';


### PR DESCRIPTION
### Description

We are missing `useK8sModel` and `useK8sModels` hooks to tap in redux and pull either single or all models. This PR will export these functions on top level of sdk utils package so we can consume it later down the line.