### PR TITLE
Bump libs to expose list view for hac-infra

### DIFF
--- a/packages/lib-core/package.json
+++ b/packages/lib-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk",
-  "version": "1.0.0-alpha10",
+  "version": "1.0.0-alpha11",
   "description": "Allows loading, managing and interpreting dynamic plugins",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-utils",
-  "version": "1.0.0-alpha12",
+  "version": "1.0.0-alpha13",
   "description": "Provides React focused plugin SDK initialization and utilities",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/lib-webpack/package.json
+++ b/packages/lib-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-webpack",
-  "version": "1.0.0-alpha6",
+  "version": "1.0.0-alpha7",
   "description": "Allows building dynamic plugin assets with webpack",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Also includes newly exported hooks for the feature flag model extension in hac-core.