### PR TITLE
Fix incorrect storing key for core resources

### DIFF
--- a/packages/lib-utils/src/app/api-discovery/index.ts
+++ b/packages/lib-utils/src/app/api-discovery/index.ts
@@ -30,7 +30,9 @@ const pluralizeKind = (kind: string): string => {
 
 const defineModels = (list: APIResourceList): K8sModelCommon[] => {
   const { groupVersion } = list;
-  const [apiGroup, apiVersion] = groupVersion.split('/');
+  const [apiGroup, apiVersion] = `${groupVersion.includes('/') ? '' : '/'}${groupVersion}`.split(
+    '/',
+  );
   if (!list.resources || list.resources.length < 1) {
     return [];
   }
@@ -134,13 +136,13 @@ const getResources = async (
     },
     {},
   );
-  const all = _.flatten(
-    apiResourceData.groups.map<string[]>((group) =>
-      group.versions.map<string>((version) => `/apis/${version.groupVersion}`),
-    ),
-  )
-    .concat(['/api/v1'])
-    .sort((api) => (preferenceList.find((item) => api.includes(`/apis/${item}`)) ? -1 : 0));
+  const all = ['/api/v1'].concat(
+    _.flatten(
+      apiResourceData.groups.map<string[]>((group) =>
+        group.versions.map<string>((version) => `/apis/${version.groupVersion}`),
+      ),
+    ).sort((api) => (preferenceList.find((item) => api.includes(`/apis/${item}`)) ? -1 : 0)),
+  );
 
   // let batchedData: APIResourceList[] = [];
   const batches = _.chunk(all, API_DISCOVERY_REQUEST_BATCH_SIZE);

--- a/packages/lib-utils/src/app/api-discovery/index.ts
+++ b/packages/lib-utils/src/app/api-discovery/index.ts
@@ -30,9 +30,7 @@ const pluralizeKind = (kind: string): string => {
 
 const defineModels = (list: APIResourceList): K8sModelCommon[] => {
   const { groupVersion } = list;
-  const [apiGroup, apiVersion] = `${groupVersion.includes('/') ? '' : '/'}${groupVersion}`.split(
-    '/',
-  );
+  const [apiVersion, apiGroup] = groupVersion.split('/').reverse();
   if (!list.resources || list.resources.length < 1) {
     return [];
   }


### PR DESCRIPTION
### Description

There's a bug where apps can't watch for core resources, because these aren't stored under proper key `$apiVersion~~$kind`, whereas it should be stored as `core~$apiVersion~$kind`. This is caused by splitting the `groupVersion` by `/`, but if no such string is found within the groupVersion it means it's just a version. So let's prepend this string with `/` if not found to properly split the string.

Since we are using batched requests let's pull for core ones first as they can't be properly sorted and are somewhat crutial to apps.