### PR TITLE
Improve api discovery by properly storing data in localStorage

### DIFF
--- a/packages/lib-utils/src/app/api-discovery/discovery-cache.ts
+++ b/packages/lib-utils/src/app/api-discovery/discovery-cache.ts
@@ -9,42 +9,44 @@ const SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = 'sdk/api-discovery-resourc
 const mergeByKey = (prev: K8sModelCommon[], next: K8sModelCommon[]) =>
   Object.values(_.merge(_.keyBy(prev, getReferenceForModel), _.keyBy(next, getReferenceForModel)));
 
-export const cacheResources = (resources: DiscoveryResources[]) => {
-  let allResources;
+const getLocalResources = () => {
   try {
-    allResources = [
-      ...[JSON.parse(localStorage.getItem(SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY) || '{}')],
-      ...resources,
-    ].reduce((acc, curr) => {
-      const { models, configResources, clusterOperatorConfigResources, ...rest } = curr || {};
-      return {
-        ..._.merge(acc, rest),
-        configResources: mergeByKey(acc?.configResources, configResources || []),
-        models: mergeByKey(acc?.models, models || []),
-        clusterOperatorConfigResources: mergeByKey(
-          acc?.clusterOperatorConfigResources,
-          clusterOperatorConfigResources || [],
-        ),
-      };
-    }, {});
+    return JSON.parse(localStorage.getItem(SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY) || '{}');
   } catch (e) {
-    consoleLogger.error('Error caching API resources in localStorage', e);
+    consoleLogger.error('Cannot load cached API resources', e);
     throw e;
   }
+};
+
+const setLocalResources = (resources: DiscoveryResources[]) => {
   try {
-    localStorage.setItem(
-      SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY,
-      JSON.stringify(allResources),
-    );
+    localStorage.setItem(SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY, JSON.stringify(resources));
   } catch (e) {
     consoleLogger.error('Error caching API resources in localStorage', e);
     throw e;
   }
 };
+export const cacheResources = (resources: DiscoveryResources[]) => {
+  const allResources = [...[getLocalResources()], ...resources].reduce(
+    (acc, curr) =>
+      _.mergeWith(acc, curr, (first, second) => {
+        if (Array.isArray(first) && first[0]?.constructor?.name === 'Object') {
+          return mergeByKey(first, second);
+        }
+
+        return undefined;
+      }),
+    {},
+  );
+  setLocalResources(allResources);
+};
 
 export const getCachedResources = () => {
   const resourcesJSON = localStorage.getItem(SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY);
   if (!resourcesJSON) {
+    consoleLogger.error(
+      `No API resources found in localStorage for key ${SDK_API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY}`,
+    );
     return null;
   }
 

--- a/packages/lib-utils/src/app/api-discovery/index.ts
+++ b/packages/lib-utils/src/app/api-discovery/index.ts
@@ -153,7 +153,7 @@ const getResources = async (
       allResources.push(resource);
       dispatch(receivedResources(resource));
     });
-    // // Cache the resources whenever discovery completes to improve console load times.
+    // Cache the resources whenever discovery completes to improve console load times.
     cacheResources(resources);
   }
   // Dispatch action to indicate all batches were loaded


### PR DESCRIPTION
### Description

There are three main changes to this PR

- Load data from localStorage before waiting for API - this ensures the models are loaded in redux before application even starts
- Store resources for each batch - whenever we request models from API we can emediately store them in localStorage, that way when user refreshes a page mid API discovery they'll get at least some resources cached
- Make a proper merge of resources - for some reason lodash's merge was messing with arrays so we stored just the most recent resources