### PR TITLE
Add sample plugin docker config

### DIFF
--- a/packages/sample-plugin/.dockerignore
+++ b/packages/sample-plugin/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/sample-plugin/Caddyfile
+++ b/packages/sample-plugin/Caddyfile
@@ -1,0 +1,17 @@
+:8000 {
+    log
+    @app_match {
+        path_regexp ^{$PLUGIN_URL}(.*)
+    }
+    handle @app_match {
+        # Substitution for alias from nginx
+        uri strip_prefix {$PLUGIN_URL}
+        file_server * {
+            root /opt/app-root/src/dist 
+            browse
+        }
+    }
+    handle / {
+        redir {$FALLBACK_URL}index.html permanent
+    }
+}

--- a/packages/sample-plugin/Dockerfile
+++ b/packages/sample-plugin/Dockerfile
@@ -1,0 +1,9 @@
+FROM quay.io/cloudservices/caddy-ubi:357c825
+
+COPY ./Caddyfile /opt/app-root/src/Caddyfile
+COPY dist /opt/app-root/src/dist/
+COPY ./package.json /opt/app-root/src
+WORKDIR /opt/app-root/src
+ENV PLUGIN_URL=/
+ENV FALLBACK_URL=/
+CMD ["caddy", "run", "--config", "/opt/app-root/src/Caddyfile"]

--- a/packages/sample-plugin/README.md
+++ b/packages/sample-plugin/README.md
@@ -1,0 +1,16 @@
+# Sample plugin
+
+### Docker config
+
+There's docker config with caddy server for easier build and run of the plugin. The Caddy config utilizes two environment variables
+
+* `PLUGIN_URL` - (*defaults to `/`*) defines which URL should be used when pulling assets, **example** `PLUGIN_URL=/foo/bar` will serve the assets on `localhost:8000/foo/bar`
+* `FALLBACK_URL` - (*defaults to `/`*) if the file is not found caddy will use this URL as a fallback and will look for index.html (SPA behavior) **example** `FALLBACK_URL=/baz` will serve the index.html from `/baz` folder.
+
+#### Running with docker
+
+The caddy server is by default serving content over from port `8000` in order to see it locally you'll have to map your machine's port to caddy's port
+
+```bash
+> docker run -p 80:8000 sample-plugin
+```


### PR DESCRIPTION
### Description

We need to have an option to spin the sample plugin with docker, this PR adds docker config with option to pass custom variables to it in order to serve the plugin on HCC.