### PR TITLE
Hide "select all" checkbox when no onSelect fn passed

### DIFF
--- a/packages/lib-utils/src/components/list-view/ListView.stories.tsx
+++ b/packages/lib-utils/src/components/list-view/ListView.stories.tsx
@@ -108,5 +108,6 @@ Primary.args = {
     },
   ],
   onFilter: undefined,
+  onSelect: undefined,
   scrollNode: undefined,
 };

--- a/packages/lib-utils/src/components/table/VirtualizedTable.tsx
+++ b/packages/lib-utils/src/components/table/VirtualizedTable.tsx
@@ -170,12 +170,14 @@ const VirtualizedTable: React.FC<VirtualizedTableProps<AnyObject>> = ({
         <TableComposable aria-label={ariaLabel} role="presentation">
           <Thead>
             <Tr>
-              <Th
-                select={{
-                  onSelect: (event, rowSelected) => onSelect?.(event, rowSelected, data),
-                  isSelected: data.every((item) => isRowSelected?.(item)),
-                }}
-              />
+              {onSelect && (
+                <Th
+                  select={{
+                    onSelect: (event, rowSelected) => onSelect?.(event, rowSelected, data),
+                    isSelected: data.every((item) => isRowSelected?.(item)),
+                  }}
+                />
+              )}
               {columns.map(
                 (
                   { title, props: properties, sort, transforms, visibility, id, info },


### PR DESCRIPTION
Fixes https://coreos.slack.com/archives/D03BC1Y958R/p1657549005264639

Fixed a bug where  "Select all" checkbox was visible even if no onSelect function has been passed to ListView.

@vidyanambiar 