### PR TITLE
Support both basic and virtualized table in ListView

### DIFF
--- a/packages/lib-utils/src/components/list-view/list-view.css
+++ b/packages/lib-utils/src/components/list-view/list-view.css
@@ -13,3 +13,7 @@
 .pf-c-toolbar__content.dps-list-view__filters {
   margin-top: calc(-1 * var(--pf-global--spacer--lg));
 }
+
+.pf-c-toolbar__item.dps-table-view-top-pagination {
+  margin-left: auto;
+}

--- a/packages/lib-utils/src/components/table/VirtualizedTable.tsx
+++ b/packages/lib-utils/src/components/table/VirtualizedTable.tsx
@@ -1,6 +1,6 @@
 import type { AnyObject } from '@monorepo/common';
 import type { IAction } from '@patternfly/react-table';
-import { Th, Thead, Tr, TableComposable } from '@patternfly/react-table';
+import { ActionsColumn, Tbody, Td, Th, Thead, Tr, TableComposable } from '@patternfly/react-table';
 import { AutoSizer, WindowScroller } from '@patternfly/react-virtualized-extension';
 import * as _ from 'lodash-es';
 import * as React from 'react';
@@ -8,7 +8,7 @@ import type { Size, WindowScrollerChildProps } from 'react-virtualized';
 import type { LoadError } from '../status/StatusBox';
 import { StatusBox } from '../status/StatusBox';
 import type { RowProps, TableColumn } from './VirtualizedTableBody';
-import VirtualizedTableBody from './VirtualizedTableBody';
+import VirtualizedTableBody, { RowMemo } from './VirtualizedTableBody';
 
 export type VirtualizedTableProps<D> = {
   /** Optional flag indicating that filters are applied to data. */
@@ -31,6 +31,8 @@ export type VirtualizedTableProps<D> = {
   isRowSelected?: (item: D) => boolean;
   /** Optional onSelect row callback */
   onSelect?: (event: React.FormEvent<HTMLInputElement>, isRowSelected: boolean, data: D[]) => void;
+  /** Optional pagination params */
+  pagination?: TablePagination;
   /** Optional no data empty state component. */
   CustomNoDataEmptyState?: React.ComponentType;
   /** Optional no applicable data empty state component. */
@@ -41,6 +43,8 @@ export type VirtualizedTableProps<D> = {
   'aria-label'?: string;
   /** Optional scroll node. */
   scrollNode?: HTMLElement;
+  /** Optional virtualized table flag */
+  virtualized?: boolean;
 };
 
 const isHTMLElement = (n: Node): n is HTMLElement => {
@@ -64,6 +68,11 @@ export const getParentScrollableElement = (node: HTMLElement) => {
   return undefined;
 };
 
+type TablePagination = {
+  limit: number;
+  offset: number;
+};
+
 type WithScrollContainerProps = {
   children: (scrollContainer: HTMLElement) => React.ReactElement | null;
 };
@@ -85,6 +94,7 @@ const VirtualizedTable: React.FC<VirtualizedTableProps<AnyObject>> = ({
   loaded,
   loadError,
   columns,
+  pagination,
   Row,
   loadErrorDefaultText,
   CustomNoDataEmptyState,
@@ -93,32 +103,50 @@ const VirtualizedTable: React.FC<VirtualizedTableProps<AnyObject>> = ({
   onSelect,
   isRowSelected,
   scrollNode,
+  virtualized,
   'aria-label': ariaLabel,
 }) => {
   const [activeSortDirection, setActiveSortDirection] = React.useState('none');
   const [activeSortIndex, setActiveSortIndex] = React.useState(-1);
   const [data, setData] = React.useState(initialData);
 
+  const paginateData = (allData: AnyObject[]) => {
+    const end =
+      pagination?.offset && pagination?.limit ? pagination.offset + pagination.limit : undefined;
+    return allData.slice(
+      virtualized ? undefined : pagination?.offset,
+      virtualized ? undefined : end,
+    );
+  };
+
+  const sortData = (index = activeSortIndex, direction = activeSortDirection) => {
+    if (direction && direction !== 'none') {
+      // back compatibility with sort column attribute defined as a string + transforms: [sortable]
+      const columnSort = _.isString(columns[index].sort) ? columns[index].sort : undefined;
+      return initialData?.sort((objA, objB) => {
+        const a = columnSort ? _.get(objA, String(columnSort)) : Object.values(objA)[index];
+        const b = columnSort ? _.get(objB, String(columnSort)) : Object.values(objB)[index];
+        if (typeof a === 'number' && typeof b === 'number') {
+          return direction === 'asc' ? a - b : b - a;
+        }
+        return direction === 'asc'
+          ? String(a).localeCompare(String(b))
+          : String(b).localeCompare(String(a));
+      });
+    }
+    return initialData;
+  };
+
   React.useEffect(() => {
-    setData(initialData);
+    setData(paginateData(sortData()));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialData]);
 
   const onSort = (event: React.FormEvent, index: number, direction: string) => {
     setActiveSortIndex(index);
     setActiveSortDirection(direction);
-    // back compatibility with sort column attribute defined as a string + transforms: [sortable]
-    const columnSort = _.isString(columns[index].sort) ? columns[index].sort : undefined;
-    const updatedRows = data.sort((objA, objB) => {
-      const a = columnSort ? _.get(objA, String(columnSort)) : Object.values(objA)[index];
-      const b = columnSort ? _.get(objB, String(columnSort)) : Object.values(objB)[index];
-      if (typeof a === 'number' && typeof b === 'number') {
-        return direction === 'asc' ? a - b : b - a;
-      }
-      return direction === 'asc'
-        ? String(a).localeCompare(String(b))
-        : String(b).localeCompare(String(a));
-    });
-    setData(updatedRows);
+    const updatedRows = sortData(index, direction);
+    setData(paginateData(updatedRows));
   };
 
   const renderVirtualizedTable = (scrollContainer: (() => HTMLElement) | HTMLElement) => (
@@ -210,12 +238,36 @@ const VirtualizedTable: React.FC<VirtualizedTableProps<AnyObject>> = ({
               {rowActions?.length > 0 && <Th />}
             </Tr>
           </Thead>
+          {(virtualized &&
+            (scrollNode ? (
+              renderVirtualizedTable(scrollNode)
+            ) : (
+              <WithScrollContainer>{renderVirtualizedTable}</WithScrollContainer>
+            ))) || (
+            <Tbody>
+              {data.map((item, index) => (
+                <Tr>
+                  {onSelect && (
+                    <Td
+                      select={{
+                        rowIndex: index,
+                        onSelect: (event, isSelected) => onSelect?.(event, isSelected, [item]),
+                        isSelected: isRowSelected?.(item) || false,
+                        disable: !!(item as Record<string, unknown>)?.disable,
+                      }}
+                    />
+                  )}
+                  <RowMemo Row={Row} obj={item} />
+                  {rowActions && (
+                    <Td isActionCell>
+                      <ActionsColumn items={rowActions} />
+                    </Td>
+                  )}
+                </Tr>
+              ))}
+            </Tbody>
+          )}
         </TableComposable>
-        {scrollNode ? (
-          renderVirtualizedTable(scrollNode)
-        ) : (
-          <WithScrollContainer>{renderVirtualizedTable}</WithScrollContainer>
-        )}
       </div>
     </StatusBox>
   );

--- a/packages/lib-utils/src/components/table/VirtualizedTableBody.tsx
+++ b/packages/lib-utils/src/components/table/VirtualizedTableBody.tsx
@@ -1,3 +1,4 @@
+import type { AnyObject } from '@monorepo/common';
 import { ActionsColumn, Td } from '@patternfly/react-table';
 import type { ICell, SortByDirection, ThProps, IAction } from '@patternfly/react-table';
 import type { ThInfoType } from '@patternfly/react-table/dist/esm/components/Table/base';
@@ -12,7 +13,12 @@ export type RowProps<D> = {
   obj: D;
 };
 
-type RowMemoProps<D> = RowProps<D> & { Row: React.ComponentType<RowProps<D>> };
+export const RowMemo: React.FC<RowMemoProps<AnyObject>> = React.memo(
+  // eslint-disable-next-line react/prop-types -- this rule has issues with React.memo
+  ({ Row: RowComponent, obj }) => <RowComponent obj={obj} />,
+);
+
+export type RowMemoProps<D> = RowProps<D> & { Row: React.ComponentType<RowProps<D>> };
 
 export type TableColumn<D> = ICell & {
   /** Column ID. */
@@ -69,7 +75,7 @@ type VirtualizedTableBodyProps<D> = {
   width: number;
 };
 
-const VirtualizedTableBody = <D,>({
+const VirtualizedTableBody = ({
   columns,
   data,
   height,
@@ -81,7 +87,7 @@ const VirtualizedTableBody = <D,>({
   rowActions,
   scrollTop,
   width,
-}: VirtualizedTableBodyProps<D>) => {
+}: VirtualizedTableBodyProps<AnyObject>) => {
   const cellMeasurementCache = new CellMeasurerCache({
     fixedWidth: true,
     minHeight: 44,
@@ -89,11 +95,6 @@ const VirtualizedTableBody = <D,>({
       (data?.[rowIndex] as unknown as Record<string, Record<string, unknown>>)?.metadata?.uid ??
       rowIndex,
   });
-
-  // eslint-disable-next-line react/prop-types -- this rule has issues with React.memo
-  const RowMemo: React.FC<RowMemoProps<D>> = React.memo(({ Row: RowComponent, obj }) => (
-    <RowComponent obj={obj} />
-  ));
 
   type RowRendererParams = {
     index: number;
@@ -105,7 +106,7 @@ const VirtualizedTableBody = <D,>({
   };
 
   const rowRenderer = ({ index, isVisible, key, parent, style }: RowRendererParams) => {
-    const rowArgs: RowProps<D> = {
+    const rowArgs: RowProps<AnyObject> = {
       obj: data[index],
     };
 


### PR DESCRIPTION
https://issues.redhat.com/browse/HAC-2006
Enabled both virtualized and non-virtualized table variants for `ListView`

Virtualization can be enabled by `virtualized` boolean property on both `ListView` and `VirtualizedTable`

Screenshot:
![image](https://user-images.githubusercontent.com/50696716/181518272-1fe4c370-6476-47ec-8c35-67af48820f03.png)

[Video non-virtualized](https://user-images.githubusercontent.com/50696716/181518972-b2045250-aaa9-4b26-9efd-e367e7e39111.webm)

[Video virtualized](https://user-images.githubusercontent.com/50696716/182166320-763f5286-d07a-46c3-b6bb-6481fcdeba17.webm)


@florkbr @vidyanambiar 
