### PR TITLE
Add plugin dependency resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "yarn workspaces foreach run build",
+    "build": "yarn build-libs && yarn build-samples",
     "build-libs": "yarn workspaces foreach --from '@openshift/*' run build",
     "build-samples": "yarn workspaces foreach --from '@monorepo/sample-*' run build",
     "run-samples": "yarn workspaces foreach -pvi --from '@monorepo/sample-*' run http-server",
@@ -53,6 +53,7 @@
     "@types/react-router": "^5.1.17",
     "@types/react-router-dom": "^5.3.3",
     "@types/react-virtualized": "^9.21.21",
+    "@types/semver": "^7.3.10",
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.3.1",
     "@typescript-eslint/parser": "^5.3.1",

--- a/packages/lib-core/package.json
+++ b/packages/lib-core/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "lodash-es": "^4.17.21",
+    "semver": "^7.3.7",
     "yup": "^0.32.11"
   },
   "peerDependenciesMeta": {

--- a/packages/lib-core/src/index.ts
+++ b/packages/lib-core/src/index.ts
@@ -13,7 +13,14 @@ export {
   EncodedExtension,
   ResolvedExtension,
 } from './types/extension';
-export { PluginEventType, PluginInfoEntry, PluginConsumer, PluginManager } from './types/store';
+export {
+  PluginEventType,
+  PluginInfoEntry,
+  LoadedPluginInfoEntry,
+  FailedPluginInfoEntry,
+  FeatureFlags,
+  PluginStoreInterface,
+} from './types/store';
 export { PluginManifest, PluginRuntimeMetadata, LoadedPlugin } from './types/plugin';
 
 // Core extension types, to be exported via lib-extensions package

--- a/packages/lib-core/src/store/PluginStoreContext.tsx
+++ b/packages/lib-core/src/store/PluginStoreContext.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { PluginConsumer, PluginManager } from '../types/store';
+import type { PluginStoreInterface } from '../types/store';
 import type { PluginStore } from './PluginStore';
 
 const PluginStoreContext = React.createContext<PluginStore | undefined>(undefined);
@@ -22,7 +22,7 @@ export type PluginStoreProviderProps = React.PropsWithChildren<{
 /**
  * React hook that provides access to the {@link PluginStore} functionality.
  */
-export const usePluginStore = (): PluginConsumer & PluginManager => {
+export const usePluginStore = (): PluginStoreInterface => {
   const store = React.useContext(PluginStoreContext);
 
   if (store === undefined) {

--- a/packages/lib-core/src/store/coderefs.ts
+++ b/packages/lib-core/src/store/coderefs.ts
@@ -17,7 +17,7 @@ class CodeRefError extends CustomError {
 }
 
 class ExtensionCodeRefsResolutionError extends CustomError {
-  constructor(readonly extension: LoadedExtension, readonly resolutionErrors: unknown[]) {
+  constructor(readonly extension: LoadedExtension, readonly causes: unknown[]) {
     super();
   }
 }

--- a/packages/lib-core/src/store/useExtensions.ts
+++ b/packages/lib-core/src/store/useExtensions.ts
@@ -1,13 +1,13 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import type { Extension, LoadedExtension, ExtensionPredicate } from '../types/extension';
-import type { PluginConsumer } from '../types/store';
+import type { PluginStoreInterface } from '../types/store';
 import { PluginEventType } from '../types/store';
 import { usePluginSubscription } from './usePluginSubscription';
 
 const eventTypes = [PluginEventType.ExtensionsChanged];
 
-const getData = (pluginConsumer: PluginConsumer) => pluginConsumer.getExtensions();
+const getData = (pluginStore: PluginStoreInterface) => pluginStore.getExtensions();
 
 const isSameData = (prevData: LoadedExtension[], nextData: LoadedExtension[]) =>
   _.isEqualWith(prevData, nextData, (a, b) => a === b);
@@ -28,9 +28,9 @@ export const useExtensions = <TExtension extends Extension>(
 
   return React.useMemo(
     () =>
-      extensions.reduce(
+      extensions.reduce<LoadedExtension<TExtension>[]>(
         (acc, e) => ((predicate ?? (() => true))(e) ? [...acc, e] : acc),
-        [] as LoadedExtension<TExtension>[],
+        [],
       ),
     [extensions, predicate],
   );

--- a/packages/lib-core/src/store/useFeatureFlag.ts
+++ b/packages/lib-core/src/store/useFeatureFlag.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { PluginConsumer } from '../types/store';
+import type { PluginStoreInterface } from '../types/store';
 import { PluginEventType } from '../types/store';
 import { usePluginStore } from './PluginStoreContext';
 import { usePluginSubscription } from './usePluginSubscription';
@@ -26,7 +26,7 @@ type UseFeatureFlagResult = [currentValue: boolean, setValue: (newValue: boolean
  */
 export const useFeatureFlag = (name: string): UseFeatureFlagResult => {
   const getData = React.useCallback(
-    (pluginConsumer: PluginConsumer) => pluginConsumer.getFeatureFlags()[name],
+    (pluginStore: PluginStoreInterface) => pluginStore.getFeatureFlags()[name],
     [name],
   );
   const currentValue = usePluginSubscription(eventTypes, getData, isSameData);

--- a/packages/lib-core/src/store/usePluginInfo.ts
+++ b/packages/lib-core/src/store/usePluginInfo.ts
@@ -1,11 +1,11 @@
 import * as _ from 'lodash-es';
-import type { PluginInfoEntry, PluginConsumer } from '../types/store';
+import type { PluginInfoEntry, PluginStoreInterface } from '../types/store';
 import { PluginEventType } from '../types/store';
 import { usePluginSubscription } from './usePluginSubscription';
 
 const eventTypes = [PluginEventType.PluginInfoChanged];
 
-const getData = (pluginConsumer: PluginConsumer) => pluginConsumer.getPluginInfo();
+const getData = (pluginStore: PluginStoreInterface) => pluginStore.getPluginInfo();
 
 /**
  * React hook for consuming current information about plugins.

--- a/packages/lib-core/src/store/usePluginSubscription.ts
+++ b/packages/lib-core/src/store/usePluginSubscription.ts
@@ -1,17 +1,17 @@
 import * as React from 'react';
-import type { PluginEventType, PluginConsumer } from '../types/store';
+import type { PluginEventType, PluginStoreInterface } from '../types/store';
 import { usePluginStore } from './PluginStoreContext';
 
 const isSameReference = (a: unknown, b: unknown) => a === b;
 
 /**
- * React hook for subscribing to `PluginStore` events via the {@link PluginConsumer} interface.
+ * React hook for subscribing to `PluginStore` events.
  *
- * This hook implements the common {@link PluginConsumer} usage pattern:
+ * This hook implements the common `PluginStore` usage pattern:
  *
  * ```
- * pluginConsumer.subscribe(eventTypes, () => {
- *   // get current data from pluginConsumer
+ * pluginStore.subscribe(eventTypes, () => {
+ *   // get current data from plugin store
  *   // compare current data with previous data
  *   // re-render the component on data change
  * });
@@ -29,7 +29,7 @@ const isSameReference = (a: unknown, b: unknown) => a === b;
  */
 export const usePluginSubscription = <TPluginData>(
   eventTypes: PluginEventType[],
-  getData: (pluginConsumer: PluginConsumer) => TPluginData,
+  getData: (pluginStore: PluginStoreInterface) => TPluginData,
   isSameData: (prevData: TPluginData, nextData: TPluginData) => boolean = isSameReference,
 ): TPluginData => {
   const pluginStore = usePluginStore();

--- a/packages/lib-core/src/store/useResolvedExtensions.ts
+++ b/packages/lib-core/src/store/useResolvedExtensions.ts
@@ -64,11 +64,7 @@ export const useResolvedExtensions = <TExtension extends Extension>(
               .map((e) => e.extension.pluginName),
           );
 
-          // TODO(vojtech): provide a way to inform consumers about plugin(s) being disabled
-          // due to code reference resolution errors
-          pluginStore.setPluginsEnabled(
-            failedPluginNames.map((pluginName) => ({ pluginName, enabled: false })),
-          );
+          pluginStore.disablePlugins(failedPluginNames, 'Code reference resolution errors');
         }
 
         setResolved(true);

--- a/packages/lib-core/src/types/plugin.ts
+++ b/packages/lib-core/src/types/plugin.ts
@@ -3,6 +3,7 @@ import type { Extension, LoadedExtension } from './extension';
 export type PluginRuntimeMetadata = {
   name: string;
   version: string;
+  dependencies?: Record<string, string>;
 };
 
 export type PluginManifest = PluginRuntimeMetadata & {
@@ -13,4 +14,10 @@ export type LoadedPlugin = {
   metadata: Readonly<PluginRuntimeMetadata>;
   extensions: Readonly<LoadedExtension[]>;
   enabled: boolean;
+  disableReason?: string;
+};
+
+export type FailedPlugin = {
+  errorMessage: string;
+  errorCause?: unknown;
 };

--- a/packages/lib-core/src/yup-schemas.ts
+++ b/packages/lib-core/src/yup-schemas.ts
@@ -81,6 +81,10 @@ export const extensionArraySchema = yup.array().of(extensionSchema).required();
 export const pluginRuntimeMetadataSchema = yup.object().required().shape({
   name: pluginNameSchema,
   version: semverStringSchema,
+  // TODO(vojtech): Yup lacks native support for map-like structures with arbitrary keys
+  // TODO(vojtech): suppress false positive https://github.com/jsx-eslint/eslint-plugin-react/pull/3326
+  // eslint-disable-next-line react/forbid-prop-types
+  dependencies: yup.object(),
 });
 
 /**

--- a/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
+++ b/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
@@ -35,7 +35,7 @@ const validateExtensions = (extensions: EncodedExtension[]) => {
 };
 
 /**
- * Settings for the global function used by plugin entry scripts.
+ * Settings for the global callback function used by plugin entry scripts.
  */
 type PluginEntryCallbackSettings = Partial<{
   /**
@@ -79,7 +79,7 @@ export type DynamicRemotePluginOptions = Partial<{
   sharedModules: WebpackSharedObject;
 
   /**
-   * Customize the global function used by plugin entry scripts at runtime.
+   * Customize the global callback function used by plugin entry scripts.
    *
    * See {@link PluginEntryCallbackSettings} properties and their defaults.
    */
@@ -164,6 +164,7 @@ export class DynamicRemotePlugin implements WebpackPluginInstance {
     new GenerateManifestPlugin(PLUGIN_MANIFEST, {
       name: this.pluginMetadata.name,
       version: this.pluginMetadata.version,
+      dependencies: this.pluginMetadata.dependencies,
       extensions: this.extensions,
     }).apply(compiler);
 

--- a/packages/sample-app/package.json
+++ b/packages/sample-app/package.json
@@ -18,6 +18,7 @@
     "@patternfly/react-icons": "^4.53.16",
     "@patternfly/react-styles": "^4.52.16",
     "@patternfly/react-table": "^4.71.16",
+    "@patternfly/react-tokens": "^4.58.5",
     "copy-webpack-plugin": "^10.2.4",
     "css-loader": "^6.7.1",
     "css-minimizer-webpack-plugin": "^3.4.1",

--- a/packages/sample-app/src/app-minimal.tsx
+++ b/packages/sample-app/src/app-minimal.tsx
@@ -19,7 +19,10 @@ render(<Loading />, appContainer);
 
 // eslint-disable-next-line promise/catch-or-return, promise/always-return
 initSharedScope().then(() => {
-  const pluginLoader = new PluginLoader({ sharedScope: getSharedScope() });
+  const pluginLoader = new PluginLoader({
+    sharedScope: getSharedScope(),
+    fixedPluginDependencyResolutions: { 'sample-app': '1.0.0' },
+  });
 
   const pluginStore = new PluginStore();
 

--- a/packages/sample-app/src/components/common/ErrorBoundary.tsx
+++ b/packages/sample-app/src/components/common/ErrorBoundary.tsx
@@ -7,7 +7,7 @@ export type ErrorBoundaryFallbackProps = {
   errorInfo: React.ErrorInfo;
 };
 
-type ErrorBoundaryProps = AnyObject;
+type ErrorBoundaryProps = React.PropsWithChildren<AnyObject>;
 
 type ErrorBoundaryState =
   | {

--- a/packages/sample-app/webpack.config.ts
+++ b/packages/sample-app/webpack.config.ts
@@ -154,6 +154,7 @@ const config: Configuration = {
             '@patternfly/react-icons',
             '@patternfly/react-styles',
             '@patternfly/react-table',
+            '@patternfly/react-tokens',
           ]),
           name: 'vendor-patternfly',
           chunks: 'all',

--- a/packages/sample-plugin/plugin.json
+++ b/packages/sample-plugin/plugin.json
@@ -1,6 +1,9 @@
 {
   "name": "sample-plugin",
   "version": "1.2.3",
+  "dependencies": {
+    "sample-app": "^1.0.0"
+  },
   "exposedModules": {
     "telemetryListener": "./src/telemetry-listener"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2556,6 +2556,7 @@ __metadata:
     "@types/react-router": ^5.1.17
     "@types/react-router-dom": ^5.3.3
     "@types/react-virtualized": ^9.21.21
+    "@types/semver": ^7.3.10
     "@types/uuid": ^8.3.4
     "@typescript-eslint/eslint-plugin": ^5.3.1
     "@typescript-eslint/parser": ^5.3.1
@@ -2615,6 +2616,7 @@ __metadata:
     "@patternfly/react-icons": ^4.53.16
     "@patternfly/react-styles": ^4.52.16
     "@patternfly/react-table": ^4.71.16
+    "@patternfly/react-tokens": ^4.58.5
     copy-webpack-plugin: ^10.2.4
     css-loader: ^6.7.1
     css-minimizer-webpack-plugin: ^3.4.1
@@ -2780,6 +2782,7 @@ __metadata:
   resolution: "@openshift/dynamic-plugin-sdk@portal:../lib-core::locator=%40monorepo%2Fsample-app%40workspace%3Apackages%2Fsample-app"
   dependencies:
     lodash-es: ^4.17.21
+    semver: ^7.3.7
     yup: ^0.32.11
   peerDependencies:
     react: ^17.0.2
@@ -2798,6 +2801,7 @@ __metadata:
   resolution: "@openshift/dynamic-plugin-sdk@portal:../lib-core::locator=%40monorepo%2Fsample-plugin%40workspace%3Apackages%2Fsample-plugin"
   dependencies:
     lodash-es: ^4.17.21
+    semver: ^7.3.7
     yup: ^0.32.11
   peerDependencies:
     react: ^17.0.2
@@ -2816,6 +2820,7 @@ __metadata:
   resolution: "@openshift/dynamic-plugin-sdk@workspace:packages/lib-core"
   dependencies:
     lodash-es: ^4.17.21
+    semver: ^7.3.7
     yup: ^0.32.11
   peerDependencies:
     react: ^17.0.2
@@ -4956,6 +4961,13 @@ __metadata:
   version: 0.16.2
   resolution: "@types/scheduler@npm:0.16.2"
   checksum: b6b4dcfeae6deba2e06a70941860fb1435730576d3689225a421280b7742318d1548b3d22c1f66ab68e414f346a9542f29240bc955b6332c5b11e561077583bc
+  languageName: node
+  linkType: hard
+
+"@types/semver@npm:^7.3.10":
+  version: 7.3.12
+  resolution: "@types/semver@npm:7.3.12"
+  checksum: 35536b2fc5602904f21cae681f6c9498e177dab3f54ae37c92f9a1b7e43c35f18bcd81e1c98c1cf0d33ee046bb06c771e9928c1c00a401d56a03f56549252a15
   languageName: node
   linkType: hard
 
@@ -17415,7 +17427,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.x, semver@npm:^7.3.2":
+"semver@npm:7.x, semver@npm:^7.3.2, semver@npm:^7.3.7":
   version: 7.3.7
   resolution: "semver@npm:7.3.7"
   dependencies:


### PR DESCRIPTION
This PR adds support for resolving plugin dependencies in a way that is compatible with openshift/console#11626.

Fixes [HAC-1720](https://issues.redhat.com/browse/HAC-1720)

Added `PluginLoader.loadPlugin` method to encapsulate the logic behind loading a plugin from the specified URL.

1. Fetch and validate the manifest (`plugin-manifest.json`).
2. Resolve plugin dependencies, if any.
3. Load and process the entry script (`plugin-entry.js`).

A plugin can declare its dependencies via the optional `dependencies` metadata field, for example:
```json
"dependencies": {
  "foobar": "~1.2.3",
  "sample-app": "^1.0.0"
},
```

There are two kinds of dependencies:
- _Regular dependencies_ refer to actual plugins that must be loaded with the right version prior to loading the plugin that depends on them.
- _Fixed dependencies_ refer to any non-plugin dependencies like host application version, runtime platform version, etc. They are specified by the host application via the `PluginLoader` option `fixedPluginDependencyResolutions`.

```ts
const pluginLoader = new PluginLoader({
  sharedScope: getSharedScope(),
  fixedPluginDependencyResolutions: { 'sample-app': '1.0.0' },
});
```

Given the examples above, `foobar` is a regular dependency while `sample-app` is a fixed dependency that represents the host application version. If the `fixedPluginDependencyResolutions` option is missing, it falls back to an empty object meaning all dependencies refer to actual plugins.

_Regular dependencies are currently not evaluated eagerly._ Loading the above plugin will not automatically trigger loading of plugin `foobar` since we currently don't have a concept of a "plugin registry" that would map plugin names to corresponding version & URL resolutions. This current behavior is consistent with openshift/console#11626 which basically requires the host application to initiate loading of all the plugins, including any dependencies of those plugins.

Dependency resolution is designed to fail early if there are any unsuccessful or unmet resolutions. If the `sample-app` fixed dependency has `2.0.0` resolution and we try to load the above plugin, the `"sample-app": "^1.0.0"` dependency will be immediately rejected as non-matching, so we won't wait for plugin `foobar` to load but fail immediately:
```
Detected 1 resolution errors with 1 pending resolutions (foobar)

Dependency sample-app not met: required range ^1.0.0, resolved version 2.0.0
```

### Code improvements

- `PluginLoader` now invokes its listeners early upon an error. This in turn allows `PluginStore` to register failed plugins even before reaching the "Load and process the entry script" step.
- When `PluginLoader` fails to load a plugin, we pass `errorMessage` and `errorCause` properties as part of the load result. These properties are exposed to consumers via `PluginStore.getPluginInfo` method.
- `PluginConsumer` and `PluginManager` interfaces have been merged into a single `PluginStoreInterface` describing the public API of `PluginStore`. Consumer APIs like the `usePluginStore` hook now work with this interface.
- Pending info entries removed from `PluginStore.getPluginInfo` method result since the `PluginLoader` currently notifies its subscribers only when a plugin has finished loading successfully or has failed to load.
- `PluginStore.setPluginsEnabled` has been split into two methods, `enablePlugins` and `disablePlugins`. The latter allows consumers to provide an optional reason why the given plugin(s) got disabled. This is also used internally when disabling a plugin due to code reference resolution errors. The `disableReason` property is exposed to consumers via `PluginStore.getPluginInfo` method.
- `sample-app` component `PluginInfoTable` improved to render `disableReason` (if present) via info icon tooltip.
