### PR TITLE
HAC-1999: Enable watching non-namespaced/global resources

### DIFF
--- a/packages/lib-utils/src/k8s/hooks/k8s-watcher.ts
+++ b/packages/lib-utils/src/k8s/hooks/k8s-watcher.ts
@@ -77,7 +77,7 @@ export const getReduxData = (immutableData, resource: WatchK8sResource) => {
 };
 
 export const getWatchData: GetWatchData = (resource, k8sModel) => {
-  if (!k8sModel || !resource?.namespace) {
+  if (!k8sModel || !resource) {
     return null;
   }
   const query = makeQuery(


### PR DESCRIPTION
This PR is required to enable watching global resource lists such as KCP Workspaces.

CC: @florkbr 