### PR TITLE
Improve the build of lib packages

### DIFF
--- a/docs/publish-packages.md
+++ b/docs/publish-packages.md
@@ -61,7 +61,7 @@ Make sure the `version` field in the relevant `package.json` file(s) has the rig
 
 ```sh
 npm pkg get version -workspace ./packages/PKG_DIR | jq -r .[]
-npm pkg set version='NEW_VERSION' -workspace ./packages/PKG_DIR
+npm pkg set version=NEW_VERSION -workspace ./packages/PKG_DIR
 ```
 
 To verify the package before publishing:

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@typescript-eslint/parser": "^5.3.1",
     "babel-loader": "^8.2.5",
     "cypress": "^9.7.0",
+    "downlevel-dts": "^0.10.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^19.0.0",
     "eslint-config-airbnb-base": "^15.0.0",
@@ -70,7 +71,9 @@
     "eslint-plugin-promise": "^5.1.1",
     "eslint-plugin-react": "^7.27.0",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "fs-extra": "^10.1.0",
     "jest": "^27.5.1",
+    "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
     "prettier": "^2.4.1",
     "react": "^17.0.2",
@@ -90,6 +93,7 @@
     "ts-jest": "^27.1.4",
     "ts-node": "^10.7.0",
     "tslib": "^2.3.1",
+    "type-fest": "^2.18.0",
     "typescript": "~4.4.4",
     "webpack": "^5.69.1"
   }

--- a/packages/common/rollup-configs.js
+++ b/packages/common/rollup-configs.js
@@ -1,55 +1,50 @@
-import { execSync } from 'child_process';
 import commonjs from '@rollup/plugin-commonjs';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import analyzer from 'rollup-plugin-analyzer';
 import dts from 'rollup-plugin-dts';
 import css from 'rollup-plugin-import-css';
+import { removeFiles } from './rollup-plugins/removeFiles';
+import { replaceCode } from './rollup-plugins/replaceCode';
+import { writeBuildMetadata } from './rollup-plugins/writeBuildMetadata';
+
+/** @typedef {import("type-fest").PackageJson} PackageJson */
 
 // https://yarnpkg.com/advanced/lifecycle-scripts#environment-variables
 const rootDir = process.env.PROJECT_CWD;
 
+/**
+ * @param {PackageJson} pkg
+ */
 const getExternalModules = (pkg) => [
   ...Object.keys(pkg.dependencies ?? {}),
   ...Object.keys(pkg.peerDependencies ?? {}),
   ...('lodash' in pkg.dependencies ? ['lodash-es'] : []),
 ];
 
+/**
+ * @param {PackageJson} pkg
+ */
 const getExternalModuleRegExps = (pkg) => {
   const externalModules = getExternalModules(pkg);
   return externalModules.map((module) => new RegExp(`^${module}(\\/.+)*$`));
 };
 
-const getBanner = (pkg) => {
-  const text = `
-  OpenShift Dynamic Plugin SDK
-  ${pkg.repository.url.replace(/\.git$/, '')}
-
-  ${pkg.name} version ${pkg.version}
-  build date ${new Date().toLocaleString('en-US', { dateStyle: 'long', timeStyle: 'long' })}
-  git commit ${execSync('git rev-parse HEAD').toString().trim()}
-  `.trim();
-
-  return `/*\n  ${text}\n */\n`;
-};
-
 /**
- * @returns {import('rollup').Plugin}
+ * @param {string} file
  */
-const replaceLodashEsRequire = () => ({
-  name: 'replace-lodash-es-require',
-
-  renderChunk(code, chunk) {
-    return {
-      code: code.replace("require('lodash-es')", "require('lodash')"),
-      map: chunk?.map,
-    };
-  },
-});
+const replaceLodashEsRequire = (file) =>
+  replaceCode({
+    file,
+    replacements: {
+      "require('lodash-es')": "require('lodash')",
+    },
+  });
 
 /**
  * Rollup configuration for generating the library `.js` bundle.
  *
+ * @param {PackageJson} pkg
  * @param {string} inputFile
  * @param {'esm' | 'cjs'} format
  * @returns {import('rollup').RollupOptions}
@@ -59,7 +54,6 @@ export const tsLibConfig = (pkg, inputFile, format = 'esm') => ({
   output: {
     file: 'dist/index.js',
     format,
-    banner: getBanner(pkg),
   },
   external: getExternalModuleRegExps(pkg),
   plugins: [
@@ -72,10 +66,14 @@ export const tsLibConfig = (pkg, inputFile, format = 'esm') => ({
       tsconfig: './tsconfig.json',
       include: ['src/**/*', '../common/src/**/*'],
     }),
-    ...(format === 'cjs' ? [replaceLodashEsRequire()] : []),
+    ...(format === 'cjs' ? [replaceLodashEsRequire('index.js')] : []),
     analyzer({
       summaryOnly: true,
       root: rootDir,
+    }),
+    writeBuildMetadata({
+      pkg,
+      outputDir: 'dist',
     }),
   ],
 });
@@ -83,6 +81,7 @@ export const tsLibConfig = (pkg, inputFile, format = 'esm') => ({
 /**
  * Rollup configuration for generating the library `.d.ts` bundle.
  *
+ * @param {PackageJson} pkg
  * @param {string} inputFile
  * @returns {import('rollup').RollupOptions}
  */
@@ -99,6 +98,9 @@ export const dtsLibConfig = (pkg, inputFile) => ({
     analyzer({
       summaryOnly: true,
       root: rootDir,
+    }),
+    removeFiles({
+      files: ['dist/types'],
     }),
   ],
 });

--- a/packages/common/rollup-plugins/removeFiles.js
+++ b/packages/common/rollup-plugins/removeFiles.js
@@ -1,0 +1,21 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+
+/**
+ * Removes the specified files or directories.
+ *
+ * @param {object} options
+ * @param {string[]} options.files
+ * @param {string} [options.cwd]
+ * @param {string} [options.hook]
+ * @returns {import('rollup').Plugin}
+ */
+export const removeFiles = ({ files, cwd = process.cwd(), hook = 'generateBundle' }) => ({
+  name: 'remove-files',
+
+  [hook]: () => {
+    files.forEach((f) => {
+      fs.removeSync(path.resolve(cwd, f));
+    });
+  },
+});

--- a/packages/common/rollup-plugins/replaceCode.js
+++ b/packages/common/rollup-plugins/replaceCode.js
@@ -1,0 +1,27 @@
+import * as _ from 'lodash';
+
+/**
+ * Allows replacing code within the given file.
+ *
+ * @param {object} options
+ * @param {string} options.file
+ * @param {Record<string, string>} options.replacements
+ * @returns {import('rollup').Plugin}
+ */
+export const replaceCode = ({ file, replacements }) => ({
+  name: 'replace-code',
+
+  renderChunk(code, chunk) {
+    if (chunk.fileName !== file) {
+      return null;
+    }
+
+    const newCode = Object.entries(replacements).reduce(
+      (acc, [searchValue, replaceValue]) =>
+        acc.replace(new RegExp(_.escapeRegExp(searchValue), 'g'), replaceValue),
+      code,
+    );
+
+    return { code: newCode, map: chunk?.map };
+  },
+});

--- a/packages/common/rollup-plugins/writeBuildMetadata.js
+++ b/packages/common/rollup-plugins/writeBuildMetadata.js
@@ -1,0 +1,35 @@
+import { execSync } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+
+/**
+ * Generates `build-meta.json` file in the given directory.
+ *
+ * @param {object} options
+ * @param {import("type-fest").PackageJson} options.pkg
+ * @param {string} options.outputDir
+ * @param {string} [options.cwd]
+ * @returns {import('rollup').Plugin}
+ */
+export const writeBuildMetadata = ({ pkg, outputDir, cwd = process.cwd() }) => ({
+  name: 'write-build-metadata',
+
+  writeBundle() {
+    const now = new Date();
+
+    fs.writeJSONSync(
+      path.resolve(cwd, outputDir, 'build-meta.json'),
+      {
+        name: pkg.name,
+        version: pkg.version,
+        buildDate: now.toLocaleString('en-US', { dateStyle: 'long' }),
+        buildTime: now.toLocaleString('en-US', { timeStyle: 'long' }),
+        gitCommit: execSync('git rev-parse HEAD').toString().trim(),
+        gitBranch: execSync('git rev-parse --abbrev-ref HEAD').toString().trim(),
+      },
+      {
+        spaces: 2,
+      },
+    );
+  },
+});

--- a/packages/lib-core/package.json
+++ b/packages/lib-core/package.json
@@ -10,16 +10,26 @@
   },
   "files": [
     "dist/index.js",
-    "dist/index.d.ts"
+    "dist/index.d.ts",
+    "dist/index.ts38.d.ts",
+    "dist/build-meta.json"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "typesVersions": {
+    "<4.0": {
+      "index.d.ts": [
+        "dist/index.ts38.d.ts"
+      ]
+    }
+  },
   "scripts": {
     "prepack": "yarn build",
     "prepublishOnly": "yarn test",
-    "build": "rm -rf dist && yarn run -T rollup -c",
+    "build": "rm -rf dist && yarn run -T rollup -c && yarn process-dts",
     "lint": "yarn run -T eslint $INIT_CWD",
-    "test": "yarn run -T test $INIT_CWD --passWithNoTests"
+    "test": "yarn run -T test $INIT_CWD --passWithNoTests",
+    "process-dts": "yarn run -T downlevel-dts dist/index.d.ts dist/index.ts38.d.ts --to=3.8"
   },
   "peerDependencies": {
     "react": "^17.0.2",

--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -10,7 +10,9 @@
   },
   "files": [
     "dist/index.js",
-    "dist/index.d.ts"
+    "dist/index.d.ts",
+    "dist/index.css",
+    "dist/build-meta.json"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/lib-webpack/package.json
+++ b/packages/lib-webpack/package.json
@@ -10,7 +10,8 @@
   },
   "files": [
     "dist/index.js",
-    "dist/index.d.ts"
+    "dist/index.d.ts",
+    "dist/build-meta.json"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2560,6 +2560,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.3.1
     babel-loader: ^8.2.5
     cypress: ^9.7.0
+    downlevel-dts: ^0.10.0
     eslint: ^7.32.0
     eslint-config-airbnb: ^19.0.0
     eslint-config-airbnb-base: ^15.0.0
@@ -2573,7 +2574,9 @@ __metadata:
     eslint-plugin-promise: ^5.1.1
     eslint-plugin-react: ^7.27.0
     eslint-plugin-react-hooks: ^4.3.0
+    fs-extra: ^10.1.0
     jest: ^27.5.1
+    lodash: ^4.17.21
     lodash-es: ^4.17.21
     prettier: ^2.4.1
     react: ^17.0.2
@@ -2593,6 +2596,7 @@ __metadata:
     ts-jest: ^27.1.4
     ts-node: ^10.7.0
     tslib: ^2.3.1
+    type-fest: ^2.18.0
     typescript: ~4.4.4
     webpack: ^5.69.1
   languageName: unknown
@@ -8773,6 +8777,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"downlevel-dts@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "downlevel-dts@npm:0.10.0"
+  dependencies:
+    semver: ^7.3.2
+    shelljs: ^0.8.3
+    typescript: next
+  bin:
+    downlevel-dts: index.js
+  checksum: c0ac21a13a5060913a31ece1af8f817d50b7ad4875cd855b34f0560d46d78e0f02b93bdd8eb81735db9cbfaeef22f56c5be4e9d74b91ea44f63c5335c0d32bbf
+  languageName: node
+  linkType: hard
+
 "duplexer@npm:~0.1.1":
   version: 0.1.2
   resolution: "duplexer@npm:0.1.2"
@@ -10699,6 +10716,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^7.0.0":
+  version: 7.2.3
+  resolution: "glob@npm:7.2.3"
+  dependencies:
+    fs.realpath: ^1.0.0
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: ^3.1.1
+    once: ^1.3.0
+    path-is-absolute: ^1.0.0
+  checksum: 29452e97b38fa704dabb1d1045350fb2467cf0277e155aa9ff7077e90ad81d1ea9d53d3ee63bd37c05b09a065e90f16aec4a65f5b8de401d1dac40bc5605d133
+  languageName: node
+  linkType: hard
+
 "glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.1.7, glob@npm:^7.2.0":
   version: 7.2.0
   resolution: "glob@npm:7.2.0"
@@ -11570,6 +11601,13 @@ __metadata:
     has: ^1.0.3
     side-channel: ^1.0.4
   checksum: 1944f92e981e47aebc98a88ff0db579fd90543d937806104d0b96557b10c1f170c51fb777b97740a8b6ddeec585fca8c39ae99fd08a8e058dfc8ab70937238bf
+  languageName: node
+  linkType: hard
+
+"interpret@npm:^1.0.0":
+  version: 1.4.0
+  resolution: "interpret@npm:1.4.0"
+  checksum: 2e5f51268b5941e4a17e4ef0575bc91ed0ab5f8515e3cf77486f7c14d13f3010df9c0959f37063dcc96e78d12dc6b0bb1b9e111cdfe69771f4656d2993d36155
   languageName: node
   linkType: hard
 
@@ -13953,7 +13991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.2":
+"minimatch@npm:^3.0.2, minimatch@npm:^3.1.1":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -16564,6 +16602,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rechoir@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "rechoir@npm:0.6.2"
+  dependencies:
+    resolve: ^1.1.6
+  checksum: fe76bf9c21875ac16e235defedd7cbd34f333c02a92546142b7911a0f7c7059d2e16f441fe6fb9ae203f459c05a31b2bcf26202896d89e390eda7514d5d2702b
+  languageName: node
+  linkType: hard
+
 "rechoir@npm:^0.7.0":
   version: 0.7.1
   resolution: "rechoir@npm:0.7.1"
@@ -16941,7 +16988,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.10.0, resolve@npm:^1.14.2, resolve@npm:^1.3.2":
+"resolve@npm:^1.1.6, resolve@npm:^1.10.0, resolve@npm:^1.14.2, resolve@npm:^1.3.2":
   version: 1.22.1
   resolution: "resolve@npm:1.22.1"
   dependencies:
@@ -16987,7 +17034,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>":
   version: 1.22.1
   resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
   dependencies:
@@ -17528,6 +17575,19 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 1a2bcae50de99034fcd92ad4212d8e01eedf52c7ec7830eedcf886622804fe36884278f2be8be0ea5fde3fd1c23911643a4e0f726c8685b61871c8908af01222
+  languageName: node
+  linkType: hard
+
+"shelljs@npm:^0.8.3":
+  version: 0.8.5
+  resolution: "shelljs@npm:0.8.5"
+  dependencies:
+    glob: ^7.0.0
+    interpret: ^1.0.0
+    rechoir: ^0.6.2
+  bin:
+    shjs: bin/shjs
+  checksum: 7babc46f732a98f4c054ec1f048b55b9149b98aa2da32f6cf9844c434b43c6251efebd6eec120937bd0999e13811ebd45efe17410edb3ca938f82f9381302748
   languageName: node
   linkType: hard
 
@@ -19019,6 +19079,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^2.18.0":
+  version: 2.18.0
+  resolution: "type-fest@npm:2.18.0"
+  checksum: 0737128d9d77b93793c6ee443e304462a792f5b723a6be035d6cb488c5610a8baa00522805421341c04324c80efba9849885bbfbc5a9623d0672fe8712969f62
+  languageName: node
+  linkType: hard
+
 "type-is@npm:~1.6.18":
   version: 1.6.18
   resolution: "type-is@npm:1.6.18"
@@ -19052,6 +19119,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:next":
+  version: 4.8.0-dev.20220729
+  resolution: "typescript@npm:4.8.0-dev.20220729"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: c83d7998d9be1403425698b8ce748b771d6cb19fe0305a829313565173f7c3054eb33d96e4d3def2da9eaaa52de111ceaf6ba0da88b4eb2f5ae7690ec0ed02e2
+  languageName: node
+  linkType: hard
+
 "typescript@npm:~4.4.4":
   version: 4.4.4
   resolution: "typescript@npm:4.4.4"
@@ -19059,6 +19136,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 89ecb8436bb48ef5594d49289f5f89103071716b6e4844278f4fb3362856e31203e187a9c76d205c3f0b674d221a058fd28310dbcbcf5d95e9a57229bb5203f1
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@next#~builtin<compat/typescript>":
+  version: 4.8.0-dev.20220729
+  resolution: "typescript@patch:typescript@npm%3A4.8.0-dev.20220729#~builtin<compat/typescript>::version=4.8.0-dev.20220729&hash=bda367"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 0ca87f649ba10e402f73cb41a9c630be6865aa097ff0d51f1c5bedd201c808d6ffca64394cbd8b7a8543f6e4dc1735fd750a0b36e69babe83c4d76d8768da9c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- create reusable Rollup plugins for common build tasks
- remove banner in the `.js` bundle in favor of `dist/build-meta.json`
- remove `dist/types` after generating the `.d.ts` bundle
- use [`downlevel-dts`](https://github.com/sandersn/downlevel-dts) tool to generate TS 3.8 compliant `.d.ts` bundle
- use TypeScript [`typesVersions`](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions) to consume the right type declarations (for `lib-core` only)