### PR TITLE
Pass options to wsAppSettings when using watch

### DIFF
--- a/packages/lib-utils/src/config.ts
+++ b/packages/lib-utils/src/config.ts
@@ -1,6 +1,6 @@
 import type { ResourceFetch } from '@monorepo/common';
 import type { Store } from 'redux';
-import type { WebSocketAppSettings } from './web-socket/types';
+import type { WebSocketAppSettings, WebSocketOptions } from './web-socket/types';
 
 export type UtilsConfig = {
   /**
@@ -16,7 +16,9 @@ export type UtilsConfig = {
   /**
    * Configure the web socket settings for your application.
    */
-  wsAppSettings: () => Promise<WebSocketAppSettings>;
+  wsAppSettings: (
+    options: WebSocketOptions & { wsPrefix?: string; pathPrefix?: string },
+  ) => Promise<WebSocketAppSettings>;
 };
 
 let config: Readonly<UtilsConfig> | undefined;

--- a/packages/lib-utils/src/k8s/hooks/k8s-watch-types.ts
+++ b/packages/lib-utils/src/k8s/hooks/k8s-watch-types.ts
@@ -1,5 +1,6 @@
 import type { K8sModelCommon, Selector } from '../../types/k8s';
 import type { ThunkDispatchFunction } from '../../types/redux';
+import type { WebSocketOptions } from '../../web-socket/types';
 import type { WatchK8sResource } from './watch-resource-types';
 
 export type WatchData = { id: string; action: ThunkDispatchFunction };
@@ -7,6 +8,7 @@ export type WatchData = { id: string; action: ThunkDispatchFunction };
 export type GetWatchData = (
   resource?: WatchK8sResource,
   k8sModel?: K8sModelCommon,
+  options?: Partial<WebSocketOptions & RequestInit & { wsPrefix?: string; pathPrefix?: string }>,
 ) => WatchData | null;
 
 export type Query = { [key: string]: unknown };

--- a/packages/lib-utils/src/k8s/hooks/k8s-watcher.ts
+++ b/packages/lib-utils/src/k8s/hooks/k8s-watcher.ts
@@ -2,6 +2,7 @@ import { CustomError } from '@monorepo/common';
 import * as _ from 'lodash-es';
 import * as k8sActions from '../../app/redux/actions/k8s';
 import type { K8sModelCommon } from '../../types/k8s';
+import type { WebSocketOptions } from '../../web-socket/types';
 import { getReferenceForModel } from '../k8s-utils';
 import type { GetWatchData, MakeQuery, Query } from './k8s-watch-types';
 import type { WatchK8sResource } from './watch-resource-types';
@@ -76,7 +77,13 @@ export const getReduxData = (immutableData, resource: WatchK8sResource) => {
   return null;
 };
 
-export const getWatchData: GetWatchData = (resource, k8sModel) => {
+export const getWatchData: GetWatchData = (
+  resource,
+  k8sModel,
+  options: Partial<
+    WebSocketOptions & RequestInit & { wsPrefix?: string; pathPrefix?: string }
+  > = {},
+) => {
   if (!k8sModel || !resource) {
     return null;
   }
@@ -97,15 +104,17 @@ export const getWatchData: GetWatchData = (resource, k8sModel) => {
       k8sModel,
       undefined,
       resource.partialMetadata,
+      options,
     );
   } else if (resource.name) {
     action = k8sActions.watchK8sObject(
       id,
       resource.name,
-      resource.namespace,
+      resource.namespace || '',
       { ...query },
       k8sModel,
       resource.partialMetadata,
+      options,
     );
   } else {
     return null;

--- a/packages/lib-utils/src/k8s/hooks/useK8sWatchResource.ts
+++ b/packages/lib-utils/src/k8s/hooks/useK8sWatchResource.ts
@@ -5,6 +5,7 @@ import * as k8sActions from '../../app/redux/actions/k8s';
 import { getReduxIdPayload } from '../../app/redux/reducers/k8s/selector';
 import type { K8sResourceCommon } from '../../types/k8s';
 import type { SDKStoreState } from '../../types/redux';
+import type { WebSocketOptions } from '../../web-socket/types';
 import { getWatchData, getReduxData, NoModelError } from './k8s-watcher';
 import { useDeepCompareMemoize } from './useDeepCompareMemoize';
 import { useK8sModel } from './useK8sModel';
@@ -16,6 +17,7 @@ const NOT_A_VALUE = '__not-a-value__';
 /**
  * Hook that retrieves the k8s resource along with status for loaded and error.
  * @param initResource options needed to watch for resource.
+ * @param options WS and fetch options passed down to WSFactory @see {@link WebSocketFactory} and when pulling the first item.
  * @return An array with first item as resource(s), second item as loaded status and third item as error state if any.
  * @example
  * ```ts
@@ -23,13 +25,14 @@ const NOT_A_VALUE = '__not-a-value__';
  *   const watchRes = {
         ...
       }
- *   const [data, loaded, error] = useK8sWatchResource(watchRes)
+ *   const [data, loaded, error] = useK8sWatchResource(watchRes, { wsPrefix: 'wss://localhost:1337/foo' })
  *   return ...
  * }
  * ```
  */
 export const useK8sWatchResource = <R extends K8sResourceCommon | K8sResourceCommon[]>(
   initResource: WatchK8sResource | null,
+  options?: Partial<WebSocketOptions & RequestInit & { wsPrefix?: string; pathPrefix?: string }>,
 ): WatchK8sResult<R> => {
   const withFallback: WatchK8sResource = initResource || { kind: NOT_A_VALUE };
   const resource = useDeepCompareMemoize(withFallback, true);
@@ -37,7 +40,10 @@ export const useK8sWatchResource = <R extends K8sResourceCommon | K8sResourceCom
 
   const [k8sModel] = useK8sModel(resource.groupVersionKind || resource.kind);
 
-  const watchData = React.useMemo(() => getWatchData(resource, k8sModel), [k8sModel, resource]);
+  const watchData = React.useMemo(
+    () => getWatchData(resource, k8sModel, options),
+    [k8sModel, resource, options],
+  );
 
   const dispatch = useDispatch();
 

--- a/packages/lib-utils/src/k8s/k8s-resource.ts
+++ b/packages/lib-utils/src/k8s/k8s-resource.ts
@@ -7,7 +7,7 @@ type K8sResourceBaseOptions<TQueryOptions = QueryOptions> = {
   model: K8sModelCommon;
   queryOptions?: TQueryOptions;
   fetchOptions?: Partial<{
-    requestInit: RequestInit;
+    requestInit: RequestInit & { wsPrefix?: string; pathPrefix?: string };
     timeout: number;
   }>;
 };

--- a/packages/lib-utils/src/k8s/k8s-utils.ts
+++ b/packages/lib-utils/src/k8s/k8s-utils.ts
@@ -153,7 +153,9 @@ export const k8sWatch = (
     ns?: string;
     fieldSelector?: string;
   } = {},
-  wsOptions: Partial<WebSocketOptions> = {},
+  options: Partial<
+    WebSocketOptions & RequestInit & { wsPrefix?: string; pathPrefix?: string }
+  > = {},
 ) => {
   const queryParams: QueryParams = { watch: 'true' };
   const opts: {
@@ -166,7 +168,7 @@ export const k8sWatch = (
     jsonParse: true,
     bufferFlushInterval: 500,
     bufferMax: 1000,
-    ...wsOptions,
+    ...options,
   };
 
   const { labelSelector } = query;

--- a/packages/lib-utils/src/web-socket/WebSocketFactory.ts
+++ b/packages/lib-utils/src/web-socket/WebSocketFactory.ts
@@ -12,7 +12,7 @@ import type {
   OpenHandler,
   WebSocketOptions,
 } from './types';
-import { applyConfigSubProtocols, applyConfigHost, createURL } from './utils';
+import { applyConfigSubProtocols, createURL } from './utils';
 
 /**
  * States the web socket can be in.
@@ -49,7 +49,7 @@ export class WebSocketFactory {
     /** Unique identifier for the web socket. */
     private readonly id: string,
     /** Options to configure the web socket with. */
-    private readonly options: WebSocketOptions,
+    private readonly options: WebSocketOptions & { wsPrefix?: string; pathPrefix?: string },
   ) {
     this.bufferMax = options.bufferMax || 0;
     this.handlers = {
@@ -103,10 +103,8 @@ export class WebSocketFactory {
     this.state = WebSocketState.INIT;
     this.messageBuffer = [];
 
-    const url = await createURL(await applyConfigHost(this.options.host), this.options.path);
-    const subProtocols = await applyConfigSubProtocols(
-      this.options.host ? this.options.subProtocols : undefined,
-    );
+    const url = await createURL(this.options);
+    const subProtocols = await applyConfigSubProtocols(this.options);
     try {
       this.ws = new WebSocket(url, subProtocols);
     } catch (e) {

--- a/packages/lib-utils/src/web-socket/utils.ts
+++ b/packages/lib-utils/src/web-socket/utils.ts
@@ -1,7 +1,16 @@
 import { getUtilsConfig } from '../config';
+import type { WebSocketOptions } from './types';
 
-export const createURL = async (host: string, path: string): Promise<string> => {
+export const applyConfigHost = async (
+  options: WebSocketOptions & { wsPrefix?: string; pathPrefix?: string },
+): Promise<string> => {
+  return options.host ?? (await getUtilsConfig().wsAppSettings(options)).host;
+};
+
+export const createURL = async (options: WebSocketOptions): Promise<string> => {
   let url;
+
+  const host = await applyConfigHost(options);
 
   if (host === 'auto') {
     if (window.location.protocol === 'https:') {
@@ -14,21 +23,20 @@ export const createURL = async (host: string, path: string): Promise<string> => 
     url = host;
   }
 
-  if (path) {
-    url += path;
+  if (options.path) {
+    url += options.path;
   }
 
-  const { urlAugment } = await getUtilsConfig().wsAppSettings();
+  const { urlAugment } = await getUtilsConfig().wsAppSettings(options);
 
   return urlAugment ? urlAugment(url) : url;
 };
 
-export const applyConfigHost = async (overrideHost?: string): Promise<string> => {
-  return overrideHost ?? (await getUtilsConfig().wsAppSettings()).host;
-};
-
 export const applyConfigSubProtocols = async (
-  overridableProtocols?: string[],
+  options: WebSocketOptions & { wsPrefix?: string; pathPrefix?: string },
 ): Promise<string[]> => {
-  return overridableProtocols ?? (await getUtilsConfig().wsAppSettings()).subProtocols;
+  return (
+    (options.host ? options.subProtocols : undefined) ??
+    (await getUtilsConfig().wsAppSettings(options)).subProtocols
+  );
 };


### PR DESCRIPTION
### Description

When using `useK8sWatchResource` and `useK8sWatchResources` consumers has no chance of setting their own host for the websocket. This PR fixes such problem by allowing to pass websocket config to these hooks, when the WS connection is created this config is later passed down to the config function that operates over it.

In this config we have to allow WSConfig and also FetchConfig because before connecting to websockets we'll pull data from regular GET request. We'll also have to support any extra config passed from the plugin down to host app since the host app knows what options to consume.

### JIRA

https://issues.redhat.com/browse/HAC-2026