### PR TITLE
Add isExternal to navigation href item

### DIFF
--- a/packages/lib-core/src/extensions/navigations.ts
+++ b/packages/lib-core/src/extensions/navigations.ts
@@ -19,6 +19,8 @@ export type HrefNavItem = Extension<
     namespaced?: boolean;
     /** if true, adds /k8s/ns/active-namespace to the begining */
     prefixNamespaced?: boolean;
+    /** if true, app should open new tab with the href */
+    isExternal?: boolean;
   }
 >;
 


### PR DESCRIPTION
### Description

Since we want to support full navigation options in CRC we should support `isExternal` flag.