### PR TITLE
Fail Rollup build on TypeScript errors

### DIFF
--- a/packages/common/rollup-configs.js
+++ b/packages/common/rollup-configs.js
@@ -71,6 +71,7 @@ export const tsLibConfig = (pkg, inputFile, format = 'esm') => ({
     typescript({
       tsconfig: './tsconfig.json',
       include: ['src/**/*', '../common/src/**/*'],
+      noEmitOnError: true,
     }),
     ...(format === 'cjs' ? [replaceLodashEsRequire()] : []),
     analyzer({


### PR DESCRIPTION
By default, `@rollup/plugin-typescript` treats type errors as warnings without aborting the build.

https://github.com/rollup/plugins/tree/master/packages/typescript#noemitonerror

This works for e.g. web applications that commonly utilize Rollup watch mode, allowing the build to recover from type errors in between code changes. However, when building a library from TypeScript sources, this effectively causes the offending code to be removed from the compilation, leading to a discrepancy between sources vs. output.

This PR follows the approach recommended by the above mentioned plugin by setting `noEmitOnError: true` within the plugin configuration. There's one downside, only the first type error will be reported before the build is aborted.

An alternative would be to use Rollup [https://rollupjs.org/guide/en/#onwarn](onwarn) handler, check if the warning comes from the above mentioned plugin, and generate an error per each such warning. The downside here is the added complexity.

Edit: there doesn't seem to be an API to allow the following code to aggregate multiple error messages
```ts
onwarn: (warning, defaultHandler) => {
  if (warning.code === 'PLUGIN_WARNING' && warning.plugin === 'typescript') {
    throw new Error(warning.message);
  }
  defaultHandler(warning);
},
```
so we go with the recommended `noEmitOnError: true` approach.