### PR TITLE
Bump core SDK packages to latest

### DIFF
--- a/packages/lib-core/package.json
+++ b/packages/lib-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk",
-  "version": "1.0.0-alpha12",
+  "version": "1.0.0-alpha13",
   "description": "Allows loading, managing and interpreting dynamic plugins",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-utils",
-  "version": "1.0.0-alpha14",
+  "version": "1.0.0-alpha15",
   "description": "Provides React focused plugin SDK initialization and utilities",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/lib-webpack/package.json
+++ b/packages/lib-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-webpack",
-  "version": "1.0.0-alpha8",
+  "version": "1.0.0-alpha9",
   "description": "Allows building dynamic plugin assets with webpack",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Includes typescript fixes for external (link) navigation items, build
fixes, and console fix for TS 3.8.