### PR TITLE
Add missing row key

### DIFF
--- a/packages/lib-utils/src/components/table/VirtualizedTable.tsx
+++ b/packages/lib-utils/src/components/table/VirtualizedTable.tsx
@@ -244,7 +244,7 @@ const VirtualizedTable: React.FC<VirtualizedTableProps<AnyObject>> = ({
             ))) || (
             <Tbody>
               {data.map((item, index) => (
-                <Tr>
+                <Tr key={`row-${item.id}`}>
                   {onSelect && (
                     <Td
                       select={{


### PR DESCRIPTION
This should fix the warning thrown by `VirtualizedTable` saying that the row key is missing.

@vidyanambiar 