### PR TITLE
Fix typesVersions file mapping

### DIFF
--- a/packages/lib-core/package.json
+++ b/packages/lib-core/package.json
@@ -18,7 +18,7 @@
   "types": "dist/index.d.ts",
   "typesVersions": {
     ">=3.8 <4.0": {
-      "index.d.ts": [
+      "dist/index.d.ts": [
         "dist/index.ts38.d.ts"
       ]
     }


### PR DESCRIPTION
The path requested by TypeScript seems to be relative to package root directory.