### PR TITLE
Pass correct props to rowActions onClick

### DIFF
--- a/packages/lib-utils/src/components/table/VirtualizedTable.tsx
+++ b/packages/lib-utils/src/components/table/VirtualizedTable.tsx
@@ -262,7 +262,14 @@ const VirtualizedTable: React.FC<VirtualizedTableProps<AnyObject>> = ({
                   <RowMemo Row={Row} obj={item} />
                   {rowActions && (
                     <Td isActionCell>
-                      <ActionsColumn items={rowActions} />
+                      <ActionsColumn
+                        items={rowActions}
+                        rowData={item}
+                        extraData={{
+                          rowIndex: index,
+                          id: (item.id || item.uuid) as string,
+                        }}
+                      />
                     </Td>
                   )}
                 </Tr>


### PR DESCRIPTION
This adds passing row data as row actions' `onClick` function params.

Thanks @kdoberst for reporting that!