### PR TITLE
Tweak test config and update docs

### DIFF
--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -2,7 +2,8 @@
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) current [Active LTS](https://nodejs.org/en/about/releases/) release
+- [Node.js](https://nodejs.org/) version used by
+  [ci-operator-buildroot](../docker/Dockerfile.ci-operator-buildroot) image
 - [Yarn](https://yarnpkg.com/getting-started/install) package manager
 
 ## GitHub repo setup

--- a/docs/publish-packages.md
+++ b/docs/publish-packages.md
@@ -2,7 +2,8 @@
 
 ## Check Node.js version
 
-Use the current [Active LTS](https://nodejs.org/en/about/releases/) release.
+Use the [Node.js](https://nodejs.org/) version used by
+[ci-operator-buildroot](../docker/Dockerfile.ci-operator-buildroot) image.
 
 ## Check npm version
 

--- a/packages/common/test-configs/jest-config-react.ts
+++ b/packages/common/test-configs/jest-config-react.ts
@@ -7,10 +7,8 @@ const config: InitialOptionsTsJest = {
   testEnvironment: 'jsdom',
 
   // https://github.com/jsdom/jsdom#simple-options
-  // https://github.com/jsdom/jsdom#pretending-to-be-a-visual-browser
   testEnvironmentOptions: {
     url: 'http://localhost/',
-    pretendToBeVisual: true,
   },
 
   setupFilesAfterEnv: [path.resolve(__dirname, 'setup-react.ts')],

--- a/packages/common/test-configs/setup-react.ts
+++ b/packages/common/test-configs/setup-react.ts
@@ -2,10 +2,8 @@
 // https://github.com/testing-library/jest-dom#custom-matchers
 import '@testing-library/jest-dom';
 
-import type { AnyObject } from '../src/types/common';
-
 jest.mock('react', () => ({
-  ...jest.requireActual<AnyObject>('react'),
+  ...jest.requireActual('react'),
   useLayoutEffect: jest.requireActual('react').useEffect,
 }));
 

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,5 @@ yarn lint
 # Run unit tests
 yarn test
 
-# Upload code coverage (CI environment only)
-if [[ -n "${CI:=}" ]]; then
-  ./prow-codecov.sh 2>/dev/null
-fi
+# Upload code coverage
+./prow-codecov.sh 2>/dev/null


### PR DESCRIPTION
- remove jsdom `pretendToBeVisual` option since it doesn't seem to have any effect on our tests
- update docs to refer to the `ci-operator-buildroot` image in relation to Node.js version
- remove `[[ -n "${CI:=}" ]]` check in `test.sh` since all of our scripts use `set -u` anyway