### PR TITLE
[HAC-2112] Common details page header component

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Storybook Debug",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run storybook",
+      "internalConsoleOptions": "openOnFirstSessionStart",
+      "serverReadyAction": {
+        "pattern": "Local:.+(https?://[^:]+:[0-9]+)",
+        "uriFormat": "%s",
+        "action": "debugWithChrome"
+      }
+    }
+  ]
+}

--- a/packages/lib-utils/src/components/details-page-header/DetailsPageHeader.stories.tsx
+++ b/packages/lib-utils/src/components/details-page-header/DetailsPageHeader.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import { CheckCircleIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon, GithubIcon } from '@patternfly/react-icons';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
 import React from 'react';
 import { MemoryRouter, Routes, Route, Link } from 'react-router-dom';
@@ -56,9 +56,12 @@ Primary.args = {
     { name: 'Workspace details', path: '/workspaces/demo-workspace' },
   ],
   obj: mockWorkspace,
-  pageHeadingLabel: {
-    name: 'Ready',
-    icon: <CheckCircleIcon color="#3E8635" />,
+  pageHeading: {
+    label: {
+      name: 'Ready',
+      icon: <CheckCircleIcon color="#3E8635" />,
+    },
+    iconAfterTitle: <GithubIcon color="#0066CC" />,
   },
   actionButtons: [
     {

--- a/packages/lib-utils/src/components/details-page-header/DetailsPageHeader.stories.tsx
+++ b/packages/lib-utils/src/components/details-page-header/DetailsPageHeader.stories.tsx
@@ -1,0 +1,109 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import { CheckCircleIcon } from '@patternfly/react-icons';
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+import React from 'react';
+import { MemoryRouter, Routes, Route, Link } from 'react-router-dom';
+import type { K8sResourceCommon } from '../../types/k8s';
+import { DetailsPageHeader } from './DetailsPageHeader';
+
+const meta: ComponentMeta<typeof DetailsPageHeader> = {
+  title: 'DetailsPageHeader',
+  component: DetailsPageHeader,
+  argTypes: {},
+};
+
+export default meta;
+
+const DetailsPageHeaderTemplate: ComponentStory<typeof DetailsPageHeader> = (args) => {
+  return (
+    <MemoryRouter initialEntries={['/workspaces/demo-workspace']}>
+      <Routes>
+        <Route element={<DetailsPageHeader {...args} />} path="/workspaces/demo-workspace" />
+        <Route
+          element={
+            <div>
+              <p>Workspaces List Page</p>
+              <button type="button">
+                <Link to="/workspaces/demo-workspace">Demo Workspace</Link>
+              </button>
+            </div>
+          }
+          path="/workspaces"
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+export const Primary = DetailsPageHeaderTemplate.bind({});
+
+const mockWorkspace: K8sResourceCommon = {
+  apiVersion: 'v1beta1',
+  apiGroup: 'tenancy.kcp.dev',
+  kind: 'Workspace',
+  metadata: {
+    name: 'demo-workspace',
+    labels: {
+      label1: 'value1',
+      label2: 'value2',
+    },
+  },
+};
+
+Primary.args = {
+  breadcrumbs: [
+    { name: 'Workspaces', path: '/workspaces' },
+    { name: 'Workspace details', path: '/workspaces/demo-workspace' },
+  ],
+  obj: mockWorkspace,
+  pageHeadingLabel: {
+    name: 'Ready',
+    icon: <CheckCircleIcon color="#3E8635" />,
+  },
+  actionButtons: [
+    {
+      label: 'Test',
+      callback: (event: React.MouseEvent) => {
+        // eslint-disable-next-line no-console
+        console.log('Test Action', event);
+      },
+    },
+  ],
+  actionMenu: {
+    actions: [
+      {
+        id: '1',
+        label: 'Edit Action',
+        cta: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          callback: (event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent) => {
+            // eslint-disable-next-line no-console
+            console.log('Edit Action', event);
+          },
+        },
+        tooltip: 'Sample tooltip',
+      },
+      {
+        id: '2',
+        label: 'Delete Action',
+        cta: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          callback: (event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent) => {
+            // eslint-disable-next-line no-console
+            console.log('Delete Action', event);
+          },
+        },
+        isDisabled: true,
+      },
+      {
+        id: 'Link1',
+        label: 'External Link',
+        cta: {
+          href: 'https://github.com/',
+          external: true,
+        },
+      },
+    ],
+    isDisabled: false,
+  },
+};

--- a/packages/lib-utils/src/components/details-page-header/DetailsPageHeader.test.tsx
+++ b/packages/lib-utils/src/components/details-page-header/DetailsPageHeader.test.tsx
@@ -1,0 +1,89 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import type { DetailsPageHeaderProps } from './DetailsPageHeader';
+import { DetailsPageHeader } from './DetailsPageHeader';
+
+const mockCallback = jest.fn();
+
+const mockProps: DetailsPageHeaderProps = {
+  breadcrumbs: [
+    { name: 'Workspaces', path: '/workspaces' },
+    { name: 'Workspace details', path: '/workspaces/demo-workspace' },
+  ],
+  pageHeading: 'demo-workspace',
+  actionButtons: [
+    {
+      label: 'Test Button',
+      callback: mockCallback,
+    },
+  ],
+  actionMenu: {
+    actions: [
+      {
+        id: '2',
+        label: 'Delete Action',
+        cta: {
+          callback: jest.fn(),
+        },
+        isDisabled: true,
+      },
+      {
+        id: 'Link1',
+        label: 'Link1',
+        cta: {
+          href: '#',
+        },
+      },
+    ],
+    isDisabled: false,
+  },
+};
+
+const detailsPageHeaderJSX = (args: DetailsPageHeaderProps) => (
+  <MemoryRouter initialEntries={['/workspaces/demo-workspace']}>
+    <Routes>
+      <Route element={<DetailsPageHeader {...args} />} path="/workspaces/demo-workspace" />
+      <Route element={<div>Workspaces List Page</div>} path="/workspaces" />
+    </Routes>
+  </MemoryRouter>
+);
+
+describe('DetailsPageHeader', () => {
+  test('DetailsPageHeader is rendered with breadcrumbs, heading, action buttons and action menu', () => {
+    render(detailsPageHeaderJSX(mockProps));
+
+    // Breadcrumbs
+    expect(screen.getByText('Workspaces')).toBeVisible();
+    expect(screen.getByText('Workspace details')).toBeVisible();
+    // Page heading
+    expect(screen.getByText('demo-workspace')).toBeVisible();
+    // Action buttons
+    expect(screen.getByText('Test Button')).toBeVisible();
+    // Action menu
+    expect(screen.getByText('Actions')).toBeVisible();
+  });
+  test('Clicking on breadcrumb triggers specified path', () => {
+    render(detailsPageHeaderJSX(mockProps));
+
+    // Click Workspaces link
+    fireEvent.click(screen.getByTestId('breadcrumb-link-0'));
+    expect(screen.getByText('Workspaces List Page')).toBeVisible();
+  });
+  test('Clicking on actions menu reveals menu options', () => {
+    render(detailsPageHeaderJSX(mockProps));
+
+    fireEvent.click(screen.getByText('Actions'));
+    expect(screen.getByText('Link1')).toBeVisible();
+    expect(screen.getByText('Delete Action')).toBeVisible();
+    expect(screen.getByText('Delete Action').closest('a')).toHaveAttribute('aria-disabled');
+  });
+  test('Action button triggers callback', () => {
+    render(detailsPageHeaderJSX(mockProps));
+
+    fireEvent.click(screen.getByText('Test Button'));
+    expect(mockCallback).toHaveBeenCalled();
+  });
+});

--- a/packages/lib-utils/src/components/details-page-header/DetailsPageHeader.test.tsx
+++ b/packages/lib-utils/src/components/details-page-header/DetailsPageHeader.test.tsx
@@ -13,7 +13,9 @@ const mockProps: DetailsPageHeaderProps = {
     { name: 'Workspaces', path: '/workspaces' },
     { name: 'Workspace details', path: '/workspaces/demo-workspace' },
   ],
-  pageHeading: 'demo-workspace',
+  pageHeading: {
+    title: 'demo-workspace',
+  },
   actionButtons: [
     {
       label: 'Test Button',

--- a/packages/lib-utils/src/components/details-page-header/DetailsPageHeader.tsx
+++ b/packages/lib-utils/src/components/details-page-header/DetailsPageHeader.tsx
@@ -1,0 +1,108 @@
+import {
+  Split,
+  SplitItem,
+  TextContent,
+  Text,
+  TextVariants,
+  Label,
+  DropdownPosition,
+} from '@patternfly/react-core';
+import * as _ from 'lodash';
+import React from 'react';
+import type { K8sResourceCommon } from '../../types/k8s';
+import type { BreadcrumbProp, ActionButtonProp, ActionMenuProps } from './utils';
+import { Breadcrumbs, ActionButtons, ActionMenu } from './utils';
+import '@patternfly/react-styles/css/utilities/Spacing/spacing.css';
+
+export type DetailsPageHeaderProps = {
+  breadcrumbs: BreadcrumbProp[];
+  actionButtons?: ActionButtonProp[];
+  pageHeading?: string;
+  obj?: K8sResourceCommon;
+  pageHeadingLabel?: {
+    name: string;
+    key?: string;
+    icon?: React.ReactNode;
+    href?: string;
+    color?: 'blue' | 'cyan' | 'green' | 'orange' | 'purple' | 'red' | 'grey';
+  };
+  actionMenu?: ActionMenuProps;
+};
+
+export const DetailsPageHeader: React.SFC<DetailsPageHeaderProps> = ({
+  breadcrumbs,
+  actionButtons,
+  actionMenu,
+  pageHeading,
+  obj,
+  pageHeadingLabel,
+}) => {
+  const heading = pageHeading ?? obj?.metadata?.name;
+  return (
+    <>
+      <Split hasGutter className="pf-u-mb-sm">
+        {/* Breadcrumbs */}
+        <SplitItem>
+          <Breadcrumbs breadcrumbs={breadcrumbs} />
+        </SplitItem>
+        <SplitItem isFilled />
+      </Split>
+      <Split hasGutter className="pf-u-mb-sm pf-u-mr-sm">
+        {/* Details page heading */}
+        {heading && (
+          <SplitItem>
+            <TextContent>
+              <Text component={TextVariants.h1}>{heading}</Text>
+            </TextContent>
+          </SplitItem>
+        )}
+        {/* Optional details page heading label */}
+        {!_.isEmpty(pageHeadingLabel) && (
+          <SplitItem>
+            <Label
+              href={pageHeadingLabel?.href}
+              icon={pageHeadingLabel?.icon}
+              color={pageHeadingLabel?.color}
+              key={pageHeadingLabel?.key ?? pageHeadingLabel?.name}
+            >
+              {pageHeadingLabel?.name}
+            </Label>
+          </SplitItem>
+        )}
+        <SplitItem isFilled />
+        {/* Optional action buttons */}
+        {!_.isEmpty(actionButtons) && Array.isArray(actionButtons) && (
+          <SplitItem>
+            <ActionButtons actionButtons={actionButtons} />
+          </SplitItem>
+        )}
+        {/* Optional action menu - ungrouped actions */}
+        {actionMenu && Array.isArray(actionMenu?.actions) && (
+          <SplitItem>
+            <ActionMenu
+              actions={actionMenu?.actions}
+              isDisabled={actionMenu?.isDisabled}
+              variant={actionMenu?.variant}
+              label={actionMenu?.label}
+              position={DropdownPosition.right}
+            />
+          </SplitItem>
+        )}
+        {/* Optional action menu - Grouped actions */}
+        {actionMenu && Array.isArray(actionMenu?.groupedActions) && (
+          <SplitItem>
+            <ActionMenu
+              groupedActions={actionMenu?.groupedActions}
+              isDisabled={actionMenu?.isDisabled}
+              variant={actionMenu?.variant}
+              label={actionMenu?.label}
+              position={DropdownPosition.right}
+            />
+          </SplitItem>
+        )}
+      </Split>
+    </>
+  );
+};
+
+export default DetailsPageHeader;

--- a/packages/lib-utils/src/components/details-page-header/DetailsPageHeader.tsx
+++ b/packages/lib-utils/src/components/details-page-header/DetailsPageHeader.tsx
@@ -14,18 +14,29 @@ import type { BreadcrumbProp, ActionButtonProp, ActionMenuProps } from './utils'
 import { Breadcrumbs, ActionButtons, ActionMenu } from './utils';
 import '@patternfly/react-styles/css/utilities/Spacing/spacing.css';
 
-export type DetailsPageHeaderProps = {
-  breadcrumbs: BreadcrumbProp[];
-  actionButtons?: ActionButtonProp[];
-  pageHeading?: string;
-  obj?: K8sResourceCommon;
-  pageHeadingLabel?: {
+export type PageHeading = {
+  /** Optional title for page heading */
+  title?: string;
+  /** Optional label for page heading */
+  label?: {
     name: string;
     key?: string;
     icon?: React.ReactNode;
     href?: string;
     color?: 'blue' | 'cyan' | 'green' | 'orange' | 'purple' | 'red' | 'grey';
   };
+  /** Optional icon for page heading (appears to the left of the page heading's title) */
+  iconBeforeTitle?: React.ReactNode;
+  /** Optional icon for page heading (appears to the right of the page heading's title) */
+  iconAfterTitle?: React.ReactNode;
+};
+
+export type DetailsPageHeaderProps = {
+  breadcrumbs: BreadcrumbProp[];
+  actionButtons?: ActionButtonProp[];
+  pageHeading?: PageHeading;
+  /** Optional resource object (if no title for the page heading is provided, the title can be taken from the resource's name) */
+  obj?: K8sResourceCommon;
   actionMenu?: ActionMenuProps;
 };
 
@@ -35,9 +46,8 @@ export const DetailsPageHeader: React.SFC<DetailsPageHeaderProps> = ({
   actionMenu,
   pageHeading,
   obj,
-  pageHeadingLabel,
 }) => {
-  const heading = pageHeading ?? obj?.metadata?.name;
+  const heading = pageHeading?.title ?? obj?.metadata?.name;
   return (
     <>
       <Split hasGutter className="pf-u-mb-sm">
@@ -48,6 +58,12 @@ export const DetailsPageHeader: React.SFC<DetailsPageHeaderProps> = ({
         <SplitItem isFilled />
       </Split>
       <Split hasGutter className="pf-u-mb-sm pf-u-mr-sm">
+        {/** Icon for details page heading (before title) */}
+        {pageHeading && !_.isEmpty(pageHeading?.iconBeforeTitle) && (
+          <SplitItem className="pf-u-mt-auto pf-u-mb-auto">
+            {pageHeading?.iconBeforeTitle}
+          </SplitItem>
+        )}
         {/* Details page heading */}
         {heading && (
           <SplitItem>
@@ -56,16 +72,20 @@ export const DetailsPageHeader: React.SFC<DetailsPageHeaderProps> = ({
             </TextContent>
           </SplitItem>
         )}
+        {/** Icon for details page heading (after title) */}
+        {pageHeading && !_.isEmpty(pageHeading?.iconAfterTitle) && (
+          <SplitItem className="pf-u-mt-auto pf-u-mb-auto">{pageHeading?.iconAfterTitle}</SplitItem>
+        )}
         {/* Optional details page heading label */}
-        {!_.isEmpty(pageHeadingLabel) && (
+        {!_.isEmpty(pageHeading) && !_.isEmpty(pageHeading?.label) && (
           <SplitItem>
             <Label
-              href={pageHeadingLabel?.href}
-              icon={pageHeadingLabel?.icon}
-              color={pageHeadingLabel?.color}
-              key={pageHeadingLabel?.key ?? pageHeadingLabel?.name}
+              href={pageHeading?.label?.href}
+              icon={pageHeading?.label?.icon}
+              color={pageHeading?.label?.color}
+              key={pageHeading?.label?.key ?? pageHeading?.label?.name}
             >
-              {pageHeadingLabel?.name}
+              {pageHeading?.label?.name}
             </Label>
           </SplitItem>
         )}

--- a/packages/lib-utils/src/components/details-page-header/index.ts
+++ b/packages/lib-utils/src/components/details-page-header/index.ts
@@ -1,0 +1,1 @@
+export { DetailsPageHeader, DetailsPageHeaderProps } from './DetailsPageHeader';

--- a/packages/lib-utils/src/components/details-page-header/utils/ActionButtons.stories.tsx
+++ b/packages/lib-utils/src/components/details-page-header/utils/ActionButtons.stories.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+import React from 'react';
+import { ActionButtons } from './ActionButtons';
+
+const meta: ComponentMeta<typeof ActionButtons> = {
+  title: 'ActionButtons',
+  component: ActionButtons,
+  argTypes: {},
+};
+
+export default meta;
+
+const ActionButtonsTemplate: ComponentStory<typeof ActionButtons> = (args) => {
+  return <ActionButtons {...args} />;
+};
+
+export const Actions = ActionButtonsTemplate.bind({});
+
+Actions.args = {
+  actionButtons: [
+    {
+      label: 'Edit Workspace',
+      callback: (event: React.MouseEvent) => {
+        // eslint-disable-next-line no-console
+        console.log('Edit Workspace', event);
+      },
+    },
+    {
+      label: 'Delete Workspace',
+      callback: (event: React.MouseEvent) => {
+        // eslint-disable-next-line no-console
+        console.log('Delete Workspace', event);
+      },
+      isDisabled: true,
+    },
+  ],
+};

--- a/packages/lib-utils/src/components/details-page-header/utils/ActionButtons.test.tsx
+++ b/packages/lib-utils/src/components/details-page-header/utils/ActionButtons.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import { ActionButtons } from './ActionButtons';
+
+const mockCallback = jest.fn();
+
+const mockActionButtons = [
+  {
+    label: 'Edit Workspace',
+    callback: mockCallback,
+  },
+  {
+    label: 'Delete Workspace',
+    callback: jest.fn(),
+    isDisabled: true,
+    tooltip: 'Deletion is currently unavailable',
+  },
+];
+
+describe('ActionButtons', () => {
+  test('Buttons are rendered', () => {
+    render(<ActionButtons actionButtons={mockActionButtons} />);
+
+    expect(screen.getByText('Edit Workspace')).toBeVisible();
+    expect(screen.getByText('Delete Workspace')).toBeVisible();
+    expect(screen.getByText('Delete Workspace').closest('button')).toHaveAttribute('aria-disabled');
+  });
+  test('Button clicks trigger callback', () => {
+    render(<ActionButtons actionButtons={mockActionButtons} />);
+
+    fireEvent.click(screen.getByText('Edit Workspace'));
+    expect(mockCallback).toHaveBeenCalled();
+  });
+});

--- a/packages/lib-utils/src/components/details-page-header/utils/ActionButtons.tsx
+++ b/packages/lib-utils/src/components/details-page-header/utils/ActionButtons.tsx
@@ -1,0 +1,49 @@
+import { Button, Flex, FlexItem, Tooltip } from '@patternfly/react-core';
+import * as _ from 'lodash-es';
+import React from 'react';
+
+export type ActionButtonProp = {
+  label: string;
+  callback: (event: React.MouseEvent) => void;
+  isDisabled?: boolean;
+  tooltip?: string;
+};
+
+export type ActionButtonsProps = {
+  actionButtons: ActionButtonProp[];
+};
+
+export const ActionButtons: React.SFC<ActionButtonsProps> = ({ actionButtons }) => (
+  <Flex>
+    {_.map(actionButtons, (actionButton, i) => {
+      if (!_.isEmpty(actionButton)) {
+        return (
+          <FlexItem key={i}>
+            {actionButton.tooltip ? (
+              <Tooltip content={actionButton.tooltip}>
+                <Button
+                  variant="primary"
+                  onClick={actionButton.callback}
+                  isAriaDisabled={actionButton.isDisabled}
+                >
+                  {actionButton.label}
+                </Button>
+              </Tooltip>
+            ) : (
+              <Button
+                variant="primary"
+                onClick={actionButton.callback}
+                isAriaDisabled={actionButton.isDisabled}
+              >
+                {actionButton.label}
+              </Button>
+            )}
+          </FlexItem>
+        );
+      }
+      return null;
+    })}
+  </Flex>
+);
+
+export default ActionButtons;

--- a/packages/lib-utils/src/components/details-page-header/utils/ActionMenu.css
+++ b/packages/lib-utils/src/components/details-page-header/utils/ActionMenu.css
@@ -1,0 +1,12 @@
+.menu-item-with-label-before-icon .pf-c-dropdown__menu-item-icon {
+  margin-left: var(--pf-c-dropdown__menu-item-icon--MarginRight);
+}
+
+.menu-item-with-label-before-icon.pf-c-dropdown__menu-item {
+  flex-direction: row-reverse;
+  justify-content: left;
+}
+
+.menu-item-with-label-before-icon .pf-c-dropdown__menu-item-main {
+  flex-direction: row-reverse;
+}

--- a/packages/lib-utils/src/components/details-page-header/utils/ActionMenu.stories.tsx
+++ b/packages/lib-utils/src/components/details-page-header/utils/ActionMenu.stories.tsx
@@ -1,0 +1,110 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import { DropdownPosition } from '@patternfly/react-core';
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+import React from 'react';
+import { ActionMenu } from './ActionMenu';
+
+const meta: ComponentMeta<typeof ActionMenu> = {
+  title: 'ActionMenu',
+  component: ActionMenu,
+  argTypes: {},
+};
+
+export default meta;
+
+const ActionMenuTemplate: ComponentStory<typeof ActionMenu> = (args) => {
+  return <ActionMenu {...args} />;
+};
+
+export const Actions = ActionMenuTemplate.bind({});
+
+Actions.args = {
+  actions: [
+    {
+      id: '1',
+      label: 'Edit Action',
+      cta: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        callback: (event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent) => {
+          // eslint-disable-next-line no-console
+          console.log('Edit Action', event);
+        },
+      },
+      tooltip: 'Sample tooltip',
+    },
+    {
+      id: '2',
+      label: 'Delete Action',
+      cta: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        callback: (event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent) => {
+          // eslint-disable-next-line no-console
+          console.log('Delete Action', event);
+        },
+      },
+      isDisabled: true,
+    },
+  ],
+  isDisabled: false,
+  position: DropdownPosition.left,
+};
+
+export const GroupedActions = ActionMenuTemplate.bind({});
+
+GroupedActions.args = {
+  groupedActions: [
+    {
+      groupId: 'group1',
+      groupActions: [
+        {
+          id: '1',
+          label: 'Edit Action',
+          cta: {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            callback: (event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent) => {
+              // eslint-disable-next-line no-console
+              console.log('Edit Action', event);
+            },
+          },
+          tooltip: 'Sample tooltip',
+        },
+        {
+          id: '2',
+          label: 'Delete Action',
+          cta: {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            callback: (event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent) => {
+              // eslint-disable-next-line no-console
+              console.log('Delete Action', event);
+            },
+          },
+          isDisabled: true,
+        },
+      ],
+    },
+    {
+      groupId: 'group2',
+      groupLabel: 'Group2',
+      groupActions: [
+        {
+          id: 'Link1',
+          label: 'External Link',
+          cta: {
+            href: 'https://github.com/',
+            external: true,
+          },
+        },
+        {
+          id: 'Link2',
+          label: 'Link',
+          cta: {
+            href: '/#',
+            external: false,
+          },
+          tooltip: 'Link',
+        },
+      ],
+    },
+  ],
+  position: DropdownPosition.left,
+};

--- a/packages/lib-utils/src/components/details-page-header/utils/ActionMenu.stories.tsx
+++ b/packages/lib-utils/src/components/details-page-header/utils/ActionMenu.stories.tsx
@@ -2,12 +2,12 @@
 import { DropdownPosition } from '@patternfly/react-core';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
 import React from 'react';
-import { ActionMenu } from './ActionMenu';
+import { ActionMenu, ActionMenuVariant } from './ActionMenu';
 
 const meta: ComponentMeta<typeof ActionMenu> = {
   title: 'ActionMenu',
   component: ActionMenu,
-  argTypes: {},
+  argTypes: { groupedActions: { control: 'object' } },
 };
 
 export default meta;
@@ -102,9 +102,13 @@ GroupedActions.args = {
             external: false,
           },
           tooltip: 'Link',
+          description: 'Sample description',
         },
       ],
     },
   ],
+  variant: ActionMenuVariant.DROPDOWN,
+  label: 'Grouped Actions',
   position: DropdownPosition.left,
+  displayLabelBeforeIcon: true,
 };

--- a/packages/lib-utils/src/components/details-page-header/utils/ActionMenu.test.tsx
+++ b/packages/lib-utils/src/components/details-page-header/utils/ActionMenu.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import { ActionMenu } from './ActionMenu';
+
+const mockCallback = jest.fn();
+
+const mockActions = [
+  {
+    id: '1',
+    label: 'Edit Action',
+    cta: {
+      callback: mockCallback,
+    },
+  },
+  {
+    id: '2',
+    label: 'Delete Action',
+    cta: {
+      callback: jest.fn(),
+    },
+    isDisabled: true,
+  },
+];
+
+const mockGroupedActions = [
+  {
+    groupId: 'group1',
+    groupActions: [
+      {
+        id: '1',
+        label: 'Edit Action',
+        cta: {
+          callback: jest.fn(),
+        },
+        tooltip: 'Sample tooltip',
+      },
+      {
+        id: '2',
+        label: 'Delete Action',
+        cta: {
+          callback: jest.fn(),
+        },
+        isDisabled: true,
+      },
+    ],
+  },
+  {
+    groupId: 'group2',
+    groupLabel: 'Group2',
+    groupActions: [
+      {
+        id: 'Link1',
+        label: 'External Link',
+        cta: {
+          href: 'https://github.com/',
+          external: true,
+        },
+      },
+      {
+        id: 'Link2',
+        label: 'Link',
+        cta: {
+          href: '/#',
+          external: false,
+        },
+        tooltip: 'Link',
+      },
+    ],
+  },
+];
+
+describe('ActionMenu', () => {
+  test('ActionMenu is rendered', () => {
+    render(<ActionMenu actions={mockActions} />);
+
+    expect(screen.getByText('Actions')).toBeVisible();
+  });
+  test('ActionMenu dropdown is expanded', () => {
+    render(<ActionMenu actions={mockActions} label="Test Actions" />);
+
+    fireEvent.click(screen.getByText('Test Actions'));
+    expect(screen.getByText('Edit Action')).toBeVisible();
+    expect(screen.getByText('Delete Action')).toBeVisible();
+    expect(screen.getByText('Delete Action').closest('a')).toHaveAttribute('aria-disabled');
+  });
+  test('ActionMenu is disabled', () => {
+    render(<ActionMenu actions={mockActions} isDisabled />);
+
+    expect(screen.getByText('Actions').closest('button')).toHaveAttribute('disabled');
+  });
+  test('Menu actions trigger callback', () => {
+    render(<ActionMenu actions={mockActions} />);
+
+    fireEvent.click(screen.getByText('Actions'));
+    expect(screen.getByText('Edit Action')).toBeVisible();
+    fireEvent.click(screen.getByText('Edit Action'));
+    expect(mockCallback).toHaveBeenCalled();
+  });
+  test('Menu actions are rendered in groups', () => {
+    render(<ActionMenu groupedActions={mockGroupedActions} />);
+
+    fireEvent.click(screen.getByText('Actions'));
+    expect(screen.getByText('Edit Action')).toBeVisible();
+    expect(screen.getByText('Group2')).toBeVisible();
+    expect(screen.getByText('External Link')).toBeVisible();
+  });
+});

--- a/packages/lib-utils/src/components/details-page-header/utils/ActionMenu.tsx
+++ b/packages/lib-utils/src/components/details-page-header/utils/ActionMenu.tsx
@@ -1,0 +1,168 @@
+import type { EitherNotBoth } from '@monorepo/common';
+import {
+  Dropdown,
+  DropdownPosition,
+  DropdownGroup,
+  DropdownToggle,
+  KebabToggle,
+  DropdownItem,
+} from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import * as _ from 'lodash-es';
+import React from 'react';
+
+export type ActionCTA =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  | { callback: (event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent) => void }
+  | { href: string; external?: boolean };
+
+export type Action = {
+  /** A unique identifier for this action. */
+  id: string;
+  /** The label to display in the UI. */
+  label: React.ReactNode;
+  /** Subtext for the menu item */
+  description?: string;
+  /** Executable callback or href.
+   * External links should automatically provide an external link icon on action.
+   * */
+  cta: ActionCTA;
+  /** Whether the action is disabled. */
+  isDisabled?: boolean;
+  /** The tooltip for this action. */
+  tooltip?: string;
+  /** The icon for this action. */
+  icon?: React.ReactNode;
+};
+
+export type GroupedActions = {
+  /** A unique identifier for this group. */
+  groupId: string;
+  /** Optional label to display as group heading */
+  groupLabel?: string;
+  /** Actions under this group. */
+  groupActions: Action[];
+};
+
+export enum ActionMenuVariant {
+  KEBAB = 'plain',
+  DROPDOWN = 'default',
+}
+
+export type ActionMenuProps = EitherNotBoth<
+  { actions: Action[] },
+  { groupedActions: GroupedActions[] }
+> & {
+  /** Optional flag to indicate whether action menu should be disabled */
+  isDisabled?: boolean;
+  /** Optional variant for action menu: DROPDOWN vs KEBAB (defaults to dropdown) */
+  variant?: ActionMenuVariant;
+  /** Optional label for action menu (defaults to 'Actions') */
+  label?: string;
+  /** Optional position (left/right) at which the action menu appears (defaults to right) */
+  position?: DropdownPosition;
+};
+
+export const ActionMenu: React.FC<ActionMenuProps> = ({
+  actions = [],
+  groupedActions = [],
+  isDisabled,
+  variant = ActionMenuVariant.DROPDOWN,
+  label = 'Actions',
+  position = DropdownPosition.right,
+}) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [isGrouped, setIsGrouped] = React.useState(false);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [dropdownActionItems, setDropdownActionItems] = React.useState<any[]>([]);
+
+  React.useEffect(() => {
+    if (!_.isEmpty(groupedActions)) {
+      setIsGrouped(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onToggle = (open: boolean) => {
+    setIsOpen(open);
+  };
+
+  const onFocus = () => {
+    const element = document.getElementById(`toggle-menu-${label}`);
+    if (element) {
+      element.focus();
+    }
+  };
+
+  const onSelect = () => {
+    setIsOpen(false);
+    onFocus();
+  };
+
+  /** Returns a DropDownItem element corresponding to an action */
+  const dropdownActionItem = React.useCallback((action: Action) => {
+    const externalIcon =
+      'href' in action.cta && 'external' in action.cta && action.cta.href && action.cta.external ? (
+        <ExternalLinkAltIcon />
+      ) : null;
+    const icon = action.icon ?? externalIcon;
+    const href = 'href' in action.cta ? action.cta.href : undefined;
+    const onClick =
+      'callback' in action.cta && action.cta.callback ? action.cta.callback : undefined;
+    return (
+      <DropdownItem
+        key={action.id}
+        tooltip={action.tooltip}
+        icon={icon}
+        href={href}
+        isDisabled={action.isDisabled}
+        onClick={onClick}
+      >
+        {action.label}
+      </DropdownItem>
+    );
+  }, []);
+
+  React.useEffect(() => {
+    let ddActionItems: JSX.Element[] = [];
+    if (!_.isEmpty(actions)) {
+      ddActionItems = actions.map((action: Action) => {
+        return dropdownActionItem(action as Action);
+      });
+    }
+    if (!_.isEmpty(groupedActions)) {
+      ddActionItems = groupedActions.map((action: GroupedActions) => {
+        // Grouped Actions
+        return (
+          <DropdownGroup label={action.groupLabel} key={action.groupId}>
+            {action.groupActions.map((groupAction: Action) => dropdownActionItem(groupAction))}
+          </DropdownGroup>
+        );
+      });
+    }
+    setDropdownActionItems(ddActionItems);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Build dropdown
+  return (
+    <Dropdown
+      onSelect={onSelect}
+      position={position}
+      toggle={
+        variant === ActionMenuVariant.DROPDOWN ? (
+          <DropdownToggle id={`toggle-menu-${label}`} onToggle={onToggle} isDisabled={isDisabled}>
+            {label}
+          </DropdownToggle>
+        ) : (
+          <KebabToggle id={`toggle-menu-${label}`} onToggle={onToggle} isDisabled={isDisabled} />
+        )
+      }
+      isOpen={isOpen}
+      dropdownItems={dropdownActionItems}
+      isGrouped={isGrouped}
+    />
+  );
+};
+
+export default ActionMenu;

--- a/packages/lib-utils/src/components/details-page-header/utils/ActionMenu.tsx
+++ b/packages/lib-utils/src/components/details-page-header/utils/ActionMenu.tsx
@@ -10,6 +10,7 @@ import {
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import * as _ from 'lodash-es';
 import React from 'react';
+import './ActionMenu.css';
 
 export type ActionCTA =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -21,17 +22,17 @@ export type Action = {
   id: string;
   /** The label to display in the UI. */
   label: React.ReactNode;
-  /** Subtext for the menu item */
+  /** Optional subtext for the menu item */
   description?: string;
   /** Executable callback or href.
    * External links should automatically provide an external link icon on action.
    * */
   cta: ActionCTA;
-  /** Whether the action is disabled. */
+  /** Optional flag to indicate whether the action is disabled. */
   isDisabled?: boolean;
-  /** The tooltip for this action. */
+  /** Optional tooltip for this action. */
   tooltip?: string;
-  /** The icon for this action. */
+  /** Optional icon for this action. */
   icon?: React.ReactNode;
 };
 
@@ -49,10 +50,7 @@ export enum ActionMenuVariant {
   DROPDOWN = 'default',
 }
 
-export type ActionMenuProps = EitherNotBoth<
-  { actions: Action[] },
-  { groupedActions: GroupedActions[] }
-> & {
+export type ActionMenuOptions = {
   /** Optional flag to indicate whether action menu should be disabled */
   isDisabled?: boolean;
   /** Optional variant for action menu: DROPDOWN vs KEBAB (defaults to dropdown) */
@@ -61,7 +59,15 @@ export type ActionMenuProps = EitherNotBoth<
   label?: string;
   /** Optional position (left/right) at which the action menu appears (defaults to right) */
   position?: DropdownPosition;
+  /** Optional flag to indicate whether labels should appear to the left of icons for the action menu items (icon appears after the label by default) */
+  displayLabelBeforeIcon?: boolean;
 };
+
+export type ActionMenuProps = EitherNotBoth<
+  { actions: Action[] },
+  { groupedActions: GroupedActions[] }
+> &
+  ActionMenuOptions;
 
 export const ActionMenu: React.FC<ActionMenuProps> = ({
   actions = [],
@@ -70,6 +76,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
   variant = ActionMenuVariant.DROPDOWN,
   label = 'Actions',
   position = DropdownPosition.right,
+  displayLabelBeforeIcon,
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [isGrouped, setIsGrouped] = React.useState(false);
@@ -100,28 +107,36 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
   };
 
   /** Returns a DropDownItem element corresponding to an action */
-  const dropdownActionItem = React.useCallback((action: Action) => {
-    const externalIcon =
-      'href' in action.cta && 'external' in action.cta && action.cta.href && action.cta.external ? (
-        <ExternalLinkAltIcon />
-      ) : null;
-    const icon = action.icon ?? externalIcon;
-    const href = 'href' in action.cta ? action.cta.href : undefined;
-    const onClick =
-      'callback' in action.cta && action.cta.callback ? action.cta.callback : undefined;
-    return (
-      <DropdownItem
-        key={action.id}
-        tooltip={action.tooltip}
-        icon={icon}
-        href={href}
-        isDisabled={action.isDisabled}
-        onClick={onClick}
-      >
-        {action.label}
-      </DropdownItem>
-    );
-  }, []);
+  const dropdownActionItem = React.useCallback(
+    (action: Action) => {
+      const externalIcon =
+        'href' in action.cta &&
+        'external' in action.cta &&
+        action.cta.href &&
+        action.cta.external ? (
+          <ExternalLinkAltIcon />
+        ) : null;
+      const icon = action.icon ?? externalIcon;
+      const href = 'href' in action.cta ? action.cta.href : undefined;
+      const onClick =
+        'callback' in action.cta && action.cta.callback ? action.cta.callback : undefined;
+      return (
+        <DropdownItem
+          className={displayLabelBeforeIcon ? 'menu-item-with-label-before-icon' : ''}
+          key={action.id}
+          tooltip={action.tooltip}
+          description={action.description}
+          icon={icon}
+          href={href}
+          isDisabled={action.isDisabled}
+          onClick={onClick}
+        >
+          {action.label}
+        </DropdownItem>
+      );
+    },
+    [displayLabelBeforeIcon],
+  );
 
   React.useEffect(() => {
     let ddActionItems: JSX.Element[] = [];

--- a/packages/lib-utils/src/components/details-page-header/utils/Breadcrumbs.stories.tsx
+++ b/packages/lib-utils/src/components/details-page-header/utils/Breadcrumbs.stories.tsx
@@ -1,0 +1,47 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+import React from 'react';
+import { MemoryRouter, Routes, Route, Link } from 'react-router-dom';
+import type { BreadcrumbProp } from './Breadcrumbs';
+import { Breadcrumbs } from './Breadcrumbs';
+
+const meta: ComponentMeta<typeof Breadcrumbs> = {
+  title: 'Breadcrumbs',
+  component: Breadcrumbs,
+  argTypes: {},
+};
+
+export default meta;
+
+const BreadcrumbsTemplate: ComponentStory<typeof Breadcrumbs> = (args) => {
+  return (
+    <MemoryRouter initialEntries={['/workspaces/demo-workspace']}>
+      <Routes>
+        <Route element={<Breadcrumbs {...args} />} path="/workspaces/demo-workspace" />
+        <Route
+          element={
+            <div>
+              <p>Workspaces List Page</p>
+              <button type="button">
+                <Link to="/workspaces/demo-workspace">Demo Workspace</Link>
+              </button>
+            </div>
+          }
+          path="/workspaces"
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+export const Primary = BreadcrumbsTemplate.bind({});
+
+// Define tabs
+const breadcrumbs: BreadcrumbProp[] = [
+  { name: 'Workspaces', path: '/workspaces' },
+  { name: 'Workspace details', path: '/workspaces/demo-workspace' },
+];
+
+Primary.args = {
+  breadcrumbs,
+};

--- a/packages/lib-utils/src/components/details-page-header/utils/Breadcrumbs.test.tsx
+++ b/packages/lib-utils/src/components/details-page-header/utils/Breadcrumbs.test.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import type { BreadcrumbsProps } from './Breadcrumbs';
+import { Breadcrumbs } from './Breadcrumbs';
+
+const mockProps: BreadcrumbsProps = {
+  breadcrumbs: [
+    { name: 'Workspaces', path: '/workspaces' },
+    { name: 'Workspace details', path: '/workspaces/demo-workspace' },
+  ],
+};
+
+const breadcrumbsJSX = (args: BreadcrumbsProps) => (
+  <MemoryRouter initialEntries={['/workspaces/demo-workspace']}>
+    <Routes>
+      <Route element={<Breadcrumbs {...args} />} path="/workspaces/demo-workspace" />
+      <Route element={<div>Workspaces List Page</div>} path="/workspaces" />
+    </Routes>
+  </MemoryRouter>
+);
+
+describe('Breadcrumbs', () => {
+  test('Breadcrumbs are rendered', () => {
+    render(breadcrumbsJSX(mockProps));
+
+    expect(screen.getByText('Workspaces')).toBeVisible();
+    expect(screen.getByText('Workspace details')).toBeVisible();
+  });
+  test('Clicking on breadcrumb triggers specified path', () => {
+    render(breadcrumbsJSX(mockProps));
+
+    // Click Workspaces link
+    fireEvent.click(screen.getByTestId('breadcrumb-link-0'));
+    expect(screen.getByText('Workspaces List Page')).toBeVisible();
+  });
+});

--- a/packages/lib-utils/src/components/details-page-header/utils/Breadcrumbs.tsx
+++ b/packages/lib-utils/src/components/details-page-header/utils/Breadcrumbs.tsx
@@ -1,0 +1,51 @@
+import { v4 as uuidv4 } from 'uuid';
+import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export type BreadcrumbProp = { name: string; path: string; uuid?: string; id?: string };
+
+export type BreadcrumbsProps = {
+  breadcrumbs: BreadcrumbProp[];
+};
+
+export const Breadcrumbs: React.SFC<BreadcrumbsProps> = ({ breadcrumbs }) => {
+  const [crumbs, setCrumbs] = React.useState<BreadcrumbProp[]>([]);
+
+  const addUUID = (allData: BreadcrumbProp[]) => {
+    return allData.map((item: BreadcrumbProp) => ({
+      ...item,
+      uuid: item.uuid || item.id || uuidv4(),
+    }));
+  };
+
+  React.useEffect(() => {
+    setCrumbs(addUUID(breadcrumbs));
+  }, [breadcrumbs]);
+
+  return (
+    <Breadcrumb>
+      {crumbs.map((crumb, i, { length }) => {
+        const isLast = i === length - 1;
+
+        return (
+          <BreadcrumbItem key={crumb.uuid} isActive={isLast}>
+            {isLast ? (
+              crumb.name
+            ) : (
+              <Link
+                className="pf-c-breadcrumb__link"
+                to={crumb.path}
+                data-testid={`breadcrumb-link-${i}`}
+              >
+                {crumb.name}
+              </Link>
+            )}
+          </BreadcrumbItem>
+        );
+      })}
+    </Breadcrumb>
+  );
+};
+
+export default Breadcrumbs;

--- a/packages/lib-utils/src/components/details-page-header/utils/index.ts
+++ b/packages/lib-utils/src/components/details-page-header/utils/index.ts
@@ -1,0 +1,9 @@
+export { Breadcrumbs, BreadcrumbProp, BreadcrumbsProps } from './Breadcrumbs';
+export { ActionButtons, ActionButtonProp, ActionButtonsProps } from './ActionButtons';
+export {
+  ActionMenu,
+  Action,
+  GroupedActions,
+  ActionMenuVariant,
+  ActionMenuProps,
+} from './ActionMenu';


### PR DESCRIPTION
Jira ticket: https://issues.redhat.com/browse/HAC-2112

This PR contains components for displaying the header section of a details page (breadcrumbs, title, labels, action buttons and action menu)

Test with `yarn storybook`

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/43621546/190510407-0282f709-37f2-4d1f-a7fc-08f95a41986c.png">
