### PR TITLE
Tune ci-operator build root Dockerfile

### DIFF
--- a/docker/Dockerfile.ci-operator-buildroot
+++ b/docker/Dockerfile.ci-operator-buildroot
@@ -12,7 +12,7 @@ ENV NO_COLOR=1
 # Note that ci-operator requires git to be installed on the system.
 # https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image
 RUN dnf update -y && \
-    dnf install -y git jq && \
+    dnf install -y git jq openssl && \
     git config --system --add safe.directory '*'
 
 # Create /go directory and make it accessible to users in the root group.
@@ -27,11 +27,20 @@ RUN mkdir /go && \
 ENV npm_config_cache=/go/.npm \
     npm_config_update_notifier=false
 
-# Install additional build dependencies.
-# Node.js (and npm) is installed via the OS provided nodejs module stream.
-RUN dnf module enable -y nodejs:16 && \
-    dnf module install -y nodejs:16 && \
-    npm install -g yarn
+# Install Node.js via Node Version Manager.
+# This also updates npm package manager to the latest available version.
+# https://github.com/nvm-sh/nvm#manual-install
+ENV NVM_DIR=/go/.nvm \
+    NVM_VERSION=v0.39.1 \
+    NODE_VERSION=v18.9.1
+RUN git clone -b $NVM_VERSION --depth 1 https://github.com/nvm-sh/nvm.git $NVM_DIR && \
+    . $NVM_DIR/nvm.sh && \
+    nvm install $NODE_VERSION && \
+    npm install -g npm
+ENV PATH=$NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
+
+# Install global npm package dependencies.
+RUN npm install -g yarn
 
 # Install Cypress related dependencies.
 # https://docs.cypress.io/guides/continuous-integration/introduction.html#Dependencies
@@ -43,4 +52,5 @@ RUN dnf clean all
 # Print post-build system information.
 RUN echo "node $(node -v)" && \
     echo "npm $(npm -v)" && \
-    echo "yarn $(yarn -v)"
+    echo "yarn $(yarn -v)" && \
+    openssl version

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -18,7 +18,7 @@ yarn build-libs
 yarn build-samples
 
 # Create a virtual X11 display via Xvfb for use with Cypress E2E testing
-Xvfb :99 -screen 0 1920x1080x24 &
+Xvfb :99 -screen 0 1920x1080x24 2>&1 > /dev/null &
 export DISPLAY=':99.0'
 
 # Start servers for sample app and sample plugin, run E2E tests and shut down the servers


### PR DESCRIPTION
Fedora 36 [comes with OpenSSL version 3.0](https://packages.fedoraproject.org/pkgs/openssl/openssl/) but Node.js v16 (current active LTS) [requires OpenSSL version 1.1.1](https://nodejs.org/en/blog/announcements/nodejs16-eol/).

[This patch](https://github.com/nodejs/node/commit/e903cd19edd27eb6375b4decbcfeff045e5e7df0) backports `--openssl-legacy-provider` option to Node.js v16 for interop with older OpenSSL version, but its usage is not recommended due to security concerns.

Given that Node.js v16 will not change the supported OpenSSL version, this PR updates the CI build root Dockerfile to install Node.js v18 via [Node Version Manager](https://github.com/nvm-sh/nvm), providing full control over the Node.js runtime and npm package manager.