### PR TITLE
Use CentOS 8 Stream based CI build root image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/coverage
+/screenshots
+**/node_modules
+**/dist

--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,8 @@
 !.yarn/sdks
 !.yarn/versions
 
-# Using Yarn node_modules linker strategy
-**/node_modules
-
-# Generated project artifacts
-**/dist
 /coverage
 /screenshots
+**/node_modules
+**/dist
 **/.DS_Store

--- a/docker/Dockerfile.ci-operator-buildroot
+++ b/docker/Dockerfile.ci-operator-buildroot
@@ -1,9 +1,9 @@
 # This Docker image is used for testing via the OpenShift CI workflow.
 #
-# To build this image locally:
-#   docker build --progress=plain - < Dockerfile.ci-operator-buildroot
+# To build this image, run the following command in project root directory:
+#   docker build -t ci-operator-buildroot --progress plain - < docker/Dockerfile.ci-operator-buildroot
 
-FROM quay.io/fedora/fedora:36-x86_64
+FROM quay.io/centos/centos:stream8
 
 # Disable color output to make log files more readable.
 ENV NO_COLOR=1
@@ -12,8 +12,9 @@ ENV NO_COLOR=1
 # Note that ci-operator requires git to be installed on the system.
 # https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image
 RUN dnf update -y && \
-    dnf install -y git jq openssl && \
-    git config --system --add safe.directory '*'
+    dnf install -y git jq openssl procps-ng && \
+    git config --system --add safe.directory '*' && \
+    git config --system advice.detachedHead false
 
 # Create /go directory and make it accessible to users in the root group.
 # Note that ci-operator requires /go directory to exist with write permission.
@@ -32,7 +33,7 @@ ENV npm_config_cache=/go/.npm \
 # https://github.com/nvm-sh/nvm#manual-install
 ENV NVM_DIR=/go/.nvm \
     NVM_VERSION=v0.39.1 \
-    NODE_VERSION=v18.9.1
+    NODE_VERSION=v16.17.1
 RUN git clone -b $NVM_VERSION --depth 1 https://github.com/nvm-sh/nvm.git $NVM_DIR && \
     . $NVM_DIR/nvm.sh && \
     nvm install $NODE_VERSION && \
@@ -44,7 +45,7 @@ RUN npm install -g yarn
 
 # Install Cypress related dependencies.
 # https://docs.cypress.io/guides/continuous-integration/introduction.html#Dependencies
-RUN dnf install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver
+RUN dnf install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib
 
 # Clean up temporary files.
 RUN dnf clean all

--- a/docker/Dockerfile.ci-operator-buildroot-test
+++ b/docker/Dockerfile.ci-operator-buildroot-test
@@ -1,0 +1,13 @@
+# This Docker image is used to verify the locally built ci-operator-buildroot image.
+#
+# To build this image, run the following command in project root directory:
+#   docker build -t ci-operator-buildroot-test --progress plain -f docker/Dockerfile.ci-operator-buildroot-test .
+
+FROM ci-operator-buildroot
+
+ARG TEST_SCRIPT='test.sh'
+
+COPY . /go/src/github.com/openshift/dynamic-plugin-sdk
+WORKDIR /go/src/github.com/openshift/dynamic-plugin-sdk
+
+RUN ./$TEST_SCRIPT

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -10,6 +10,7 @@ const config: InitialOptionsTsJest = {
     '<rootDir>/packages/lib-webpack',
   ],
 
+  collectCoverage: true,
   coverageDirectory: 'coverage',
   coverageReporters: ['json', 'lcov', 'text'],
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!**/(node_modules|dist)/**'],

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-samples": "yarn workspaces foreach --from '@monorepo/sample-*' run build",
     "run-samples": "yarn workspaces foreach -pvi --from '@monorepo/sample-*' run http-server",
     "lint": "yarn eslint packages",
-    "test": "jest --collectCoverage --logHeapUsage -w 1",
+    "test": "jest --logHeapUsage -w 1",
     "test-print-config": "jest --showConfig",
     "test-e2e": "yarn workspace @monorepo/e2e-sample-app run test-e2e",
     "test-e2e-open": "yarn workspace @monorepo/e2e-sample-app run test-e2e-open",

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -exuo pipefail
 
-print_error() { printf "%s\n" "$*" >&2; }
+# Setup environment
+export NODE_OPTIONS="--max-old-space-size=4096"
 
 # Print system information
 echo "node $(node -v)"
@@ -20,8 +21,7 @@ yarn lint
 # Run unit tests
 yarn test
 
-# Run end-to-end tests
-# TODO
-
-# Upload code coverage
-./prow-codecov.sh 2>/dev/null
+# Upload code coverage (CI environment only)
+if [[ -n "${CI:=}" ]]; then
+  ./prow-codecov.sh 2>/dev/null
+fi


### PR DESCRIPTION
- [x] modify build root image `Dockerfile.ci-operator-buildroot`
  - now based on `centos:stream8` which comes with OpenSSL 1.x
  - now using Node.js `v16.17.1` which requires OpenSSL 1.x
  - added missing test related dependencies
- [x] add build root test image `Dockerfile.ci-operator-buildroot-test`
  - used to verify that test scripts work in CI env. (`test.sh`, `test-prow-e2e.sh`)
- [x] modify basic test script `test.sh`
  - added `--max-old-space-size=4096` Node.js option
  - make sure `prow-codecov.sh` runs only in CI env.