### PR TITLE
Tune Jest test configs

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,11 +16,10 @@ const config: InitialOptionsTsJest = {
     '!**/(node_modules|dist)/**',
     '!**/*.{test,stories}.*',
   ],
-};
 
-if (process.env.CI) {
   // https://github.com/kulshekhar/ts-jest/issues/259#issuecomment-888978737
-  config.maxWorkers = 1;
-}
+  maxWorkers: 1,
+  logHeapUsage: !!process.env.CI,
+};
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-samples": "yarn workspaces foreach --from '@monorepo/sample-*' run build",
     "run-samples": "yarn workspaces foreach -pvi --from '@monorepo/sample-*' run http-server",
     "lint": "yarn eslint packages",
-    "test": "jest --logHeapUsage",
+    "test": "jest",
     "test-print-config": "jest --showConfig",
     "test-e2e": "yarn workspace @monorepo/e2e-sample-app run test-e2e",
     "test-e2e-open": "yarn workspace @monorepo/e2e-sample-app run test-e2e-open",

--- a/packages/common/test-configs/jest-config-node.ts
+++ b/packages/common/test-configs/jest-config-node.ts
@@ -9,7 +9,6 @@ const config: InitialOptionsTsJest = {
   globals: {
     'ts-jest': {
       tsconfig: path.resolve(__dirname, '../tsconfig-bases/lib-node-cjs.json'),
-      isolatedModules: true,
     },
   },
 };

--- a/packages/common/test-configs/jest-config-react.ts
+++ b/packages/common/test-configs/jest-config-react.ts
@@ -16,7 +16,6 @@ const config: InitialOptionsTsJest = {
   globals: {
     'ts-jest': {
       tsconfig: path.resolve(__dirname, '../tsconfig-bases/lib-react-esm.json'),
-      isolatedModules: true,
     },
   },
 };


### PR DESCRIPTION
This PR aims to further optimize performance of unit tests as a follow-up to #169.

### When running in any env.
- set [max workers](https://jestjs.io/docs/27.x/configuration#maxworkers-number--string) to 1

### When running in CI env.
- log [heap usage](https://jestjs.io/docs/27.x/cli#--logheapusage) by default

In practice, using a single worker should ensure a single TypeScript compilation per module, with compiled artifacts being reused in subsequent tests. In the following screenshot, only the first test suite is marked as [slow](https://jestjs.io/docs/27.x/configuration#slowtestthreshold-number), while subsequent ones run relatively fast:

![](https://user-images.githubusercontent.com/648971/197013177-2052c0e2-cfda-4c18-bb89-e0a5ece68690.png)

With max workers greater than 1, the above slow test indication would be present on every test suite.

The practical implication is that with `ts-jest` we should always set max workers to 1.