### PR TITLE
Add action buttons to list view

### DIFF
--- a/packages/lib-utils/src/components/details-page-header/utils/ActionButtons.tsx
+++ b/packages/lib-utils/src/components/details-page-header/utils/ActionButtons.tsx
@@ -3,14 +3,41 @@ import * as _ from 'lodash-es';
 import React from 'react';
 
 export type ActionButtonProp = {
-  label: string;
+  id?: string;
+  label?: string;
   callback: (event: React.MouseEvent) => void;
   isDisabled?: boolean;
   tooltip?: string;
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'link';
 };
 
 export type ActionButtonsProps = {
   actionButtons: ActionButtonProp[];
+};
+
+const ActionButton: React.FC<ActionButtonProp> = ({
+  id,
+  children,
+  callback,
+  isDisabled,
+  tooltip,
+  variant = 'primary',
+}) => {
+  const tooltipRef = React.useRef();
+  return (
+    <>
+      <Button
+        variant={variant}
+        onClick={callback}
+        isAriaDisabled={isDisabled}
+        aria-describedby={id}
+        innerRef={tooltipRef}
+      >
+        {children}
+      </Button>
+      {tooltip ? <Tooltip id={id} content={tooltip} reference={tooltipRef} /> : null}
+    </>
+  );
 };
 
 export const ActionButtons: React.SFC<ActionButtonsProps> = ({ actionButtons }) => (
@@ -18,26 +45,15 @@ export const ActionButtons: React.SFC<ActionButtonsProps> = ({ actionButtons }) 
     {_.map(actionButtons, (actionButton, i) => {
       if (!_.isEmpty(actionButton)) {
         return (
-          <FlexItem key={i}>
-            {actionButton.tooltip ? (
-              <Tooltip content={actionButton.tooltip}>
-                <Button
-                  variant="primary"
-                  onClick={actionButton.callback}
-                  isAriaDisabled={actionButton.isDisabled}
-                >
-                  {actionButton.label}
-                </Button>
-              </Tooltip>
-            ) : (
-              <Button
-                variant="primary"
-                onClick={actionButton.callback}
-                isAriaDisabled={actionButton.isDisabled}
-              >
-                {actionButton.label}
-              </Button>
-            )}
+          <FlexItem key={actionButton.id || i}>
+            <ActionButton
+              variant={actionButton.variant}
+              callback={actionButton.callback}
+              isDisabled={actionButton.isDisabled}
+              tooltip={actionButton.tooltip}
+            >
+              {actionButton.label}
+            </ActionButton>
           </FlexItem>
         );
       }

--- a/packages/lib-utils/src/components/list-view/ListView.stories.tsx
+++ b/packages/lib-utils/src/components/list-view/ListView.stories.tsx
@@ -139,4 +139,17 @@ Primary.args = {
   scrollNode: undefined,
   emptyStateDescription: 'No matching data found...',
   virtualized: false,
+  actionButtons: [
+    {
+      label: 'Add',
+      // eslint-disable-next-line no-console
+      callback: () => console.log('Adding workspace'),
+      tooltip: 'Add a workspace by clicking on the button',
+    },
+    {
+      label: 'Delete',
+      callback: () => null,
+      isDisabled: true,
+    },
+  ],
 };

--- a/packages/lib-utils/src/components/list-view/ListView.tsx
+++ b/packages/lib-utils/src/components/list-view/ListView.tsx
@@ -16,6 +16,8 @@ import { debounce, omit } from 'lodash-es';
 import * as React from 'react';
 import { useSearchParams, useLocation } from 'react-router-dom';
 import { parseFiltersFromURL, setFiltersToURL } from '../../utils/url-sync';
+import { ActionButtons } from '../details-page-header/utils/ActionButtons';
+import type { ActionButtonProp } from '../details-page-header/utils/ActionButtons';
 import type { VirtualizedTableProps } from '../table/VirtualizedTable';
 import VirtualizedTable from '../table/VirtualizedTable';
 import FilterChips from './FilterChips';
@@ -33,6 +35,7 @@ export type ListViewProps<D> = VirtualizedTableProps<D> & {
   onFilter?: (filterValues: Record<string, string[]>, activeFilter?: FilterItem) => D[];
   /** Optional array of filterBy options. */
   filters?: FilterItem[];
+  actionButtons?: ActionButtonProp[];
 };
 
 export function filterDefault<D extends Record<string, unknown>>(
@@ -65,6 +68,7 @@ const ListView = <D extends AnyObject>({
   emptyStateDescription,
   CustomNoDataEmptyState,
   'aria-label': ariaLabel,
+  actionButtons,
 }: ListViewProps<D>) => {
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -173,6 +177,7 @@ const ListView = <D extends AnyObject>({
               </ToolbarItem>
             </>
           )}
+          {actionButtons ? <ActionButtons actionButtons={actionButtons} /> : null}
           {!virtualized && (
             <ToolbarItem className="dps-table-view-top-pagination">
               <Pagination


### PR DESCRIPTION
This PR adds the ability to add call-to-action (cta) buttons to the list view header.  This is to fix a placement issue of the "add worksapce" button in HAC-Infra.

**Screenshot**
<img width="790" alt="Screen Shot 2022-10-24 at 11 20 52 PM" src="https://user-images.githubusercontent.com/82059948/197683010-d3166f42-dfd7-499f-b836-e025b5537455.png">

