### PR TITLE
Provide direct access to modules exposed by plugins

### DIFF
--- a/packages/common/src/errors/CustomError.ts
+++ b/packages/common/src/errors/CustomError.ts
@@ -1,7 +1,5 @@
 /**
  * Base class for custom errors.
- *
- * This shouldn't be needed once https://github.com/tc39/proposal-error-cause receives widespread support.
  */
 export class CustomError extends Error {
   constructor(message?: string) {

--- a/packages/common/src/errors/ErrorWithCause.ts
+++ b/packages/common/src/errors/ErrorWithCause.ts
@@ -1,0 +1,12 @@
+import { CustomError } from './CustomError';
+
+/**
+ * Custom error with a `cause` property.
+ *
+ * This shouldn't be needed once https://github.com/tc39/proposal-error-cause receives widespread support.
+ */
+export class ErrorWithCause extends CustomError {
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+  }
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,5 @@
 export * from './errors/CustomError';
+export * from './errors/ErrorWithCause';
 export * from './types/common';
 export * from './types/fetch';
 export * from './utils/logger';

--- a/packages/lib-core/src/store/coderefs.ts
+++ b/packages/lib-core/src/store/coderefs.ts
@@ -1,5 +1,5 @@
 import type { AnyObject } from '@monorepo/common';
-import { CustomError, visitDeep } from '@monorepo/common';
+import { CustomError, ErrorWithCause, visitDeep } from '@monorepo/common';
 import * as _ from 'lodash-es';
 import type {
   EncodedCodeRef,
@@ -9,12 +9,6 @@ import type {
   ResolvedExtension,
 } from '../types/extension';
 import type { PluginEntryModule } from '../types/runtime';
-
-class CodeRefError extends CustomError {
-  constructor(message: string, readonly cause?: unknown) {
-    super(message);
-  }
-}
 
 class ExtensionCodeRefsResolutionError extends CustomError {
   constructor(readonly extension: LoadedExtension, readonly causes: unknown[]) {
@@ -74,7 +68,7 @@ const createCodeRef =
     const refData = parseEncodedCodeRef(encodedCodeRef);
 
     if (!refData) {
-      throw new CodeRefError(
+      throw new ErrorWithCause(
         formatErrorMessage(`Malformed code reference '${encodedCodeRef.$codeRef}'`),
       );
     }
@@ -87,11 +81,11 @@ const createCodeRef =
       const moduleFactory = await entryModule.get(moduleName);
       referencedModule = moduleFactory();
     } catch (e) {
-      throw new CodeRefError(formatErrorMessage(`Failed to load module '${moduleName}'`), e);
+      throw new ErrorWithCause(formatErrorMessage(`Failed to load module '${moduleName}'`), e);
     }
 
     if (!_.has(referencedModule, exportName)) {
-      throw new CodeRefError(
+      throw new ErrorWithCause(
         formatErrorMessage(`Missing module export '${moduleName}.${exportName}'`),
       );
     }

--- a/packages/lib-core/src/types/plugin.ts
+++ b/packages/lib-core/src/types/plugin.ts
@@ -1,4 +1,5 @@
 import type { Extension, LoadedExtension } from './extension';
+import type { PluginEntryModule } from './runtime';
 
 export type PluginRuntimeMetadata = {
   name: string;
@@ -13,6 +14,7 @@ export type PluginManifest = PluginRuntimeMetadata & {
 export type LoadedPlugin = {
   metadata: Readonly<PluginRuntimeMetadata>;
   extensions: Readonly<LoadedExtension[]>;
+  entryModule: PluginEntryModule;
   enabled: boolean;
   disableReason?: string;
 };

--- a/packages/lib-core/src/types/store.ts
+++ b/packages/lib-core/src/types/store.ts
@@ -1,3 +1,4 @@
+import type { AnyObject } from '@monorepo/common';
 import type { LoadedExtension } from './extension';
 import type { LoadedPlugin, FailedPlugin } from './plugin';
 
@@ -99,4 +100,12 @@ export type PluginStoreInterface = {
    * Disabling a plugin puts all of its extensions out of use.
    */
   disablePlugins: (pluginNames: string[], disableReason?: string) => void;
+
+  /**
+   * Get a specific module exposed by the given plugin.
+   */
+  getExposedModule: <TModule extends AnyObject>(
+    pluginName: string,
+    moduleName: string,
+  ) => Promise<TModule>;
 };


### PR DESCRIPTION
Related to [RHCLOUD-21494](https://issues.redhat.com/browse/RHCLOUD-21494)

This PR adds `PluginStore.getExposedModule` method which can be used to access specific module exposed by a plugin.