### PR TITLE
Add option to pass static API models

### DIFF
--- a/packages/lib-utils/src/app/AppInitSDK.tsx
+++ b/packages/lib-utils/src/app/AppInitSDK.tsx
@@ -12,7 +12,7 @@ export type AppInitSDKProps = {
   configurations: {
     apiDiscovery?: InitAPIDiscovery;
     apiPriorityList?: string[];
-    staticApiModels?: Record<string, APIResourceList>;
+    staticAPIModels?: Record<string, APIResourceList>;
     appFetch: UtilsConfig['appFetch'];
     pluginStore: PluginStore;
     wsAppSettings: UtilsConfig['wsAppSettings'];
@@ -45,7 +45,7 @@ const AppInitSDK: React.FC<AppInitSDKProps> = ({ children, configurations }) => 
     wsAppSettings,
     apiDiscovery = initAPIDiscovery,
     apiPriorityList,
-    staticApiModels,
+    staticAPIModels,
   } = configurations;
 
   React.useEffect(() => {
@@ -53,11 +53,11 @@ const AppInitSDK: React.FC<AppInitSDKProps> = ({ children, configurations }) => 
       if (!isUtilsConfigSet()) {
         setUtilsConfig({ appFetch, wsAppSettings });
       }
-      apiDiscovery(store, apiPriorityList, staticApiModels);
+      apiDiscovery(store, apiPriorityList, staticAPIModels);
     } catch (e) {
       consoleLogger.warn('Error while initializing AppInitSDK', e);
     }
-  }, [apiDiscovery, appFetch, store, wsAppSettings, apiPriorityList, staticApiModels]);
+  }, [apiDiscovery, appFetch, store, wsAppSettings, apiPriorityList, staticAPIModels]);
 
   return (
     <PluginStoreProvider store={pluginStore}>

--- a/packages/lib-utils/src/app/AppInitSDK.tsx
+++ b/packages/lib-utils/src/app/AppInitSDK.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import type { UtilsConfig } from '../config';
 import { isUtilsConfigSet, setUtilsConfig } from '../config';
-import type { InitAPIDiscovery } from '../types/api-discovery';
+import type { APIResourceList, InitAPIDiscovery } from '../types/api-discovery';
 import { initAPIDiscovery } from './api-discovery';
 import { useReduxStore } from './redux';
 
@@ -12,6 +12,7 @@ export type AppInitSDKProps = {
   configurations: {
     apiDiscovery?: InitAPIDiscovery;
     apiPriorityList?: string[];
+    staticApiModels?: Record<string, APIResourceList>;
     appFetch: UtilsConfig['appFetch'];
     pluginStore: PluginStore;
     wsAppSettings: UtilsConfig['wsAppSettings'];
@@ -44,6 +45,7 @@ const AppInitSDK: React.FC<AppInitSDKProps> = ({ children, configurations }) => 
     wsAppSettings,
     apiDiscovery = initAPIDiscovery,
     apiPriorityList,
+    staticApiModels,
   } = configurations;
 
   React.useEffect(() => {
@@ -51,11 +53,11 @@ const AppInitSDK: React.FC<AppInitSDKProps> = ({ children, configurations }) => 
       if (!isUtilsConfigSet()) {
         setUtilsConfig({ appFetch, wsAppSettings });
       }
-      apiDiscovery(store, apiPriorityList);
+      apiDiscovery(store, apiPriorityList, staticApiModels);
     } catch (e) {
       consoleLogger.warn('Error while initializing AppInitSDK', e);
     }
-  }, [apiDiscovery, appFetch, store, wsAppSettings, apiPriorityList]);
+  }, [apiDiscovery, appFetch, store, wsAppSettings, apiPriorityList, staticApiModels]);
 
   return (
     <PluginStoreProvider store={pluginStore}>

--- a/packages/lib-utils/src/app/api-discovery/index.ts
+++ b/packages/lib-utils/src/app/api-discovery/index.ts
@@ -122,7 +122,7 @@ const batchResourcesRequest = (
 const getResources = async (
   preferenceList: string[],
   dispatch: Dispatch,
-  staticApiModels?: Record<string, APIResourceList>,
+  staticAPIModels?: Record<string, APIResourceList>,
 ): Promise<DiscoveryResources> => {
   const apiResourceData: APIResourceData = await commonFetchJSON('/apis');
   const groupVersionMap = apiResourceData.groups.reduce(
@@ -144,8 +144,8 @@ const getResources = async (
       ).sort((api) => (preferenceList.find((item) => api.includes(`/apis/${item}`)) ? -1 : 0)),
     )
     .map((apiEndpoint) => {
-      if (Object.prototype.hasOwnProperty.call(staticApiModels, apiEndpoint) && staticApiModels) {
-        return staticApiModels[apiEndpoint];
+      if (Object.prototype.hasOwnProperty.call(staticAPIModels, apiEndpoint) && staticAPIModels) {
+        return staticAPIModels[apiEndpoint];
       }
 
       return apiEndpoint;
@@ -171,20 +171,20 @@ const getResources = async (
 };
 
 const updateResources =
-  (preferenceList: string[], staticApiModels?: Record<string, APIResourceList>) =>
+  (preferenceList: string[], staticAPIModels?: Record<string, APIResourceList>) =>
   async (dispatch: Dispatch): Promise<DiscoveryResources> => {
     dispatch(setResourcesInFlight(true));
     dispatch(setBatchesInFlight(true));
 
-    const resources = await getResources(preferenceList, dispatch, staticApiModels);
+    const resources = await getResources(preferenceList, dispatch, staticAPIModels);
 
     return resources;
   };
 
 const startAPIDiscovery =
-  (preferenceList: string[], staticApiModels?: Record<string, APIResourceList>) =>
+  (preferenceList: string[], staticAPIModels?: Record<string, APIResourceList>) =>
   (dispatch: DispatchWithThunk) => {
-    dispatch(updateResources(preferenceList, staticApiModels))
+    dispatch(updateResources(preferenceList, staticAPIModels))
       .then((resources) => {
         return resources;
       })
@@ -195,7 +195,7 @@ const startAPIDiscovery =
 export const initAPIDiscovery: InitAPIDiscovery = (
   storeInstance,
   preferenceList = [],
-  staticApiModels = {},
+  staticAPIModels = {},
 ) => {
   const resources = getCachedResources();
   if (resources) {
@@ -204,6 +204,6 @@ export const initAPIDiscovery: InitAPIDiscovery = (
 
   consoleLogger.info(`API discovery waiting ${API_DISCOVERY_INIT_DELAY} ms before initializing`);
   window.setTimeout(() => {
-    storeInstance.dispatch(startAPIDiscovery(preferenceList, staticApiModels));
+    storeInstance.dispatch(startAPIDiscovery(preferenceList, staticAPIModels));
   }, API_DISCOVERY_INIT_DELAY);
 };

--- a/packages/lib-utils/src/types/api-discovery.ts
+++ b/packages/lib-utils/src/types/api-discovery.ts
@@ -5,6 +5,7 @@ import type { K8sVerb, K8sModelCommon } from './k8s';
 export type InitAPIDiscovery = (
   store: Store<unknown, Action<AnyAction>>,
   preferenceList?: string[],
+  staticApiModels?: Record<string, APIResourceList>,
 ) => void;
 
 export type APIResourceList = K8sModelCommon & {

--- a/packages/lib-utils/src/types/api-discovery.ts
+++ b/packages/lib-utils/src/types/api-discovery.ts
@@ -5,7 +5,7 @@ import type { K8sVerb, K8sModelCommon } from './k8s';
 export type InitAPIDiscovery = (
   store: Store<unknown, Action<AnyAction>>,
   preferenceList?: string[],
-  staticApiModels?: Record<string, APIResourceList>,
+  staticAPIModels?: Record<string, APIResourceList>,
 ) => void;
 
 export type APIResourceList = K8sModelCommon & {


### PR DESCRIPTION
### Description

API Discovery is firing too many requests when trying to map entire API. This PR adds option to pass already known api models. The consuming app will pass an object where keys will be edpoint to keep static and value will be the response itself.