### PR TITLE
Add option to allow APIs app is interested in

### DIFF
--- a/packages/lib-core/src/types/plugin.ts
+++ b/packages/lib-core/src/types/plugin.ts
@@ -4,6 +4,7 @@ import type { PluginEntryModule } from './runtime';
 export type PluginRuntimeMetadata = {
   name: string;
   version: string;
+  apiWhitelist?: Readonly<(string | undefined)[] | undefined>;
   dependencies?: Record<string, string>;
 };
 

--- a/packages/lib-core/src/types/plugin.ts
+++ b/packages/lib-core/src/types/plugin.ts
@@ -4,7 +4,7 @@ import type { PluginEntryModule } from './runtime';
 export type PluginRuntimeMetadata = {
   name: string;
   version: string;
-  apiWhitelist?: Readonly<(string | undefined)[] | undefined>;
+  apiAllowed?: Readonly<(string | undefined)[] | undefined>;
   dependencies?: Record<string, string>;
 };
 

--- a/packages/lib-core/src/yup-schemas.ts
+++ b/packages/lib-core/src/yup-schemas.ts
@@ -88,14 +88,18 @@ export const extensionArraySchema = yup.array().of(extensionSchema).required();
 /**
  * Schema for `PluginRuntimeMetadata` objects.
  */
-export const pluginRuntimeMetadataSchema = yup.object().required().shape({
-  name: pluginNameSchema,
-  version: semverStringSchema,
-  // TODO(vojtech): Yup lacks native support for map-like structures with arbitrary keys
-  // TODO(vojtech): suppress false positive https://github.com/jsx-eslint/eslint-plugin-react/pull/3326
-  // eslint-disable-next-line react/forbid-prop-types
-  dependencies: yup.object(),
-});
+export const pluginRuntimeMetadataSchema = yup
+  .object()
+  .required()
+  .shape({
+    name: pluginNameSchema,
+    version: semverStringSchema,
+    // TODO(vojtech): Yup lacks native support for map-like structures with arbitrary keys
+    // TODO(vojtech): suppress false positive https://github.com/jsx-eslint/eslint-plugin-react/pull/3326
+    // eslint-disable-next-line react/forbid-prop-types
+    dependencies: yup.object(),
+    apiWhitelist: yup.array().of(yup.string()),
+  });
 
 /**
  * Schema for `PluginManifest` objects.

--- a/packages/lib-core/src/yup-schemas.ts
+++ b/packages/lib-core/src/yup-schemas.ts
@@ -98,7 +98,7 @@ export const pluginRuntimeMetadataSchema = yup
     // TODO(vojtech): suppress false positive https://github.com/jsx-eslint/eslint-plugin-react/pull/3326
     // eslint-disable-next-line react/forbid-prop-types
     dependencies: yup.object(),
-    apiWhitelist: yup.array().of(yup.string()),
+    apiAllowed: yup.array().of(yup.string()),
   });
 
 /**

--- a/packages/lib-utils/src/app/AppInitSDK.tsx
+++ b/packages/lib-utils/src/app/AppInitSDK.tsx
@@ -12,7 +12,7 @@ export type AppInitSDKProps = {
   configurations: {
     apiDiscovery?: InitAPIDiscovery;
     apiPriorityList?: string[];
-    apiWhitelist?: string[];
+    apiAllowed?: string[];
     appFetch: UtilsConfig['appFetch'];
     pluginStore: PluginStore;
     wsAppSettings: UtilsConfig['wsAppSettings'];
@@ -45,7 +45,7 @@ const AppInitSDK: React.FC<AppInitSDKProps> = ({ children, configurations }) => 
     wsAppSettings,
     apiDiscovery = initAPIDiscovery,
     apiPriorityList,
-    apiWhitelist,
+    apiAllowed,
   } = configurations;
 
   React.useEffect(() => {
@@ -53,11 +53,11 @@ const AppInitSDK: React.FC<AppInitSDKProps> = ({ children, configurations }) => 
       if (!isUtilsConfigSet()) {
         setUtilsConfig({ appFetch, wsAppSettings });
       }
-      apiDiscovery(store, apiPriorityList, apiWhitelist);
+      apiDiscovery(store, apiPriorityList, apiAllowed);
     } catch (e) {
       consoleLogger.warn('Error while initializing AppInitSDK', e);
     }
-  }, [apiDiscovery, appFetch, store, wsAppSettings, apiPriorityList, apiWhitelist]);
+  }, [apiDiscovery, appFetch, store, wsAppSettings, apiPriorityList, apiAllowed]);
 
   return (
     <PluginStoreProvider store={pluginStore}>

--- a/packages/lib-utils/src/app/AppInitSDK.tsx
+++ b/packages/lib-utils/src/app/AppInitSDK.tsx
@@ -12,6 +12,7 @@ export type AppInitSDKProps = {
   configurations: {
     apiDiscovery?: InitAPIDiscovery;
     apiPriorityList?: string[];
+    apiWhitelist?: string[];
     appFetch: UtilsConfig['appFetch'];
     pluginStore: PluginStore;
     wsAppSettings: UtilsConfig['wsAppSettings'];
@@ -44,6 +45,7 @@ const AppInitSDK: React.FC<AppInitSDKProps> = ({ children, configurations }) => 
     wsAppSettings,
     apiDiscovery = initAPIDiscovery,
     apiPriorityList,
+    apiWhitelist,
   } = configurations;
 
   React.useEffect(() => {
@@ -51,11 +53,11 @@ const AppInitSDK: React.FC<AppInitSDKProps> = ({ children, configurations }) => 
       if (!isUtilsConfigSet()) {
         setUtilsConfig({ appFetch, wsAppSettings });
       }
-      apiDiscovery(store, apiPriorityList);
+      apiDiscovery(store, apiPriorityList, apiWhitelist);
     } catch (e) {
       consoleLogger.warn('Error while initializing AppInitSDK', e);
     }
-  }, [apiDiscovery, appFetch, store, wsAppSettings, apiPriorityList]);
+  }, [apiDiscovery, appFetch, store, wsAppSettings, apiPriorityList, apiWhitelist]);
 
   return (
     <PluginStoreProvider store={pluginStore}>

--- a/packages/lib-utils/src/app/api-discovery/index.ts
+++ b/packages/lib-utils/src/app/api-discovery/index.ts
@@ -125,7 +125,7 @@ const includesApi = (checkArray: string[], api: string) =>
 const getResources = async (
   preferenceList: string[],
   dispatch: Dispatch,
-  apiWhitelist?: string[],
+  apiAllowed?: string[],
 ): Promise<DiscoveryResources> => {
   const apiResourceData: APIResourceData = await commonFetchJSON('/apis');
   const groupVersionMap = apiResourceData.groups.reduce(
@@ -146,7 +146,7 @@ const getResources = async (
     )
       .sort((api) => (includesApi(preferenceList, api) ? -1 : 0))
       .filter((api) =>
-        apiWhitelist && apiWhitelist.length !== 0 ? includesApi(apiWhitelist, api) : true,
+      apiAllowed && apiAllowed.length !== 0 ? includesApi(apiAllowed, api) : true,
       ),
   );
 
@@ -170,19 +170,19 @@ const getResources = async (
 };
 
 const updateResources =
-  (preferenceList: string[], apiWhitelist?: string[]) =>
+  (preferenceList: string[], apiAllowed?: string[]) =>
   async (dispatch: Dispatch): Promise<DiscoveryResources> => {
     dispatch(setResourcesInFlight(true));
     dispatch(setBatchesInFlight(true));
 
-    const resources = await getResources(preferenceList, dispatch, apiWhitelist);
+    const resources = await getResources(preferenceList, dispatch, apiAllowed);
 
     return resources;
   };
 
 const startAPIDiscovery =
-  (preferenceList: string[], apiWhitelist?: string[]) => (dispatch: DispatchWithThunk) => {
-    dispatch(updateResources(preferenceList, apiWhitelist))
+  (preferenceList: string[], apiAllowed?: string[]) => (dispatch: DispatchWithThunk) => {
+    dispatch(updateResources(preferenceList, apiAllowed))
       .then((resources) => {
         return resources;
       })
@@ -193,7 +193,7 @@ const startAPIDiscovery =
 export const initAPIDiscovery: InitAPIDiscovery = (
   storeInstance,
   preferenceList = [],
-  apiWhitelist = [],
+  apiAllowed = [],
 ) => {
   const resources = getCachedResources();
   if (resources) {
@@ -202,6 +202,6 @@ export const initAPIDiscovery: InitAPIDiscovery = (
 
   consoleLogger.info(`API discovery waiting ${API_DISCOVERY_INIT_DELAY} ms before initializing`);
   window.setTimeout(() => {
-    storeInstance.dispatch(startAPIDiscovery(preferenceList, apiWhitelist));
+    storeInstance.dispatch(startAPIDiscovery(preferenceList, apiAllowed));
   }, API_DISCOVERY_INIT_DELAY);
 };

--- a/packages/lib-utils/src/types/api-discovery.ts
+++ b/packages/lib-utils/src/types/api-discovery.ts
@@ -5,7 +5,7 @@ import type { K8sVerb, K8sModelCommon } from './k8s';
 export type InitAPIDiscovery = (
   store: Store<unknown, Action<AnyAction>>,
   preferenceList?: string[],
-  apiWhitelist?: string[],
+  apiAllowed?: string[],
 ) => void;
 
 export type APIResourceList = K8sModelCommon & {

--- a/packages/lib-utils/src/types/api-discovery.ts
+++ b/packages/lib-utils/src/types/api-discovery.ts
@@ -5,6 +5,7 @@ import type { K8sVerb, K8sModelCommon } from './k8s';
 export type InitAPIDiscovery = (
   store: Store<unknown, Action<AnyAction>>,
   preferenceList?: string[],
+  apiWhitelist?: string[],
 ) => void;
 
 export type APIResourceList = K8sModelCommon & {

--- a/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
+++ b/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
@@ -165,7 +165,7 @@ export class DynamicRemotePlugin implements WebpackPluginInstance {
       name: this.pluginMetadata.name,
       version: this.pluginMetadata.version,
       dependencies: this.pluginMetadata.dependencies,
-      apiWhitelist: this.pluginMetadata.apiWhitelist,
+      apiAllowed: this.pluginMetadata.apiAllowed,
       extensions: this.extensions,
     }).apply(compiler);
 

--- a/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
+++ b/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
@@ -165,6 +165,7 @@ export class DynamicRemotePlugin implements WebpackPluginInstance {
       name: this.pluginMetadata.name,
       version: this.pluginMetadata.version,
       dependencies: this.pluginMetadata.dependencies,
+      apiWhitelist: this.pluginMetadata.apiWhitelist,
       extensions: this.extensions,
     }).apply(compiler);
 

--- a/reports/lib-core.api.md
+++ b/reports/lib-core.api.md
@@ -184,6 +184,7 @@ export type PluginManifest = PluginRuntimeMetadata & {
 export type PluginRuntimeMetadata = {
     name: string;
     version: string;
+    apiAllowed?: Readonly<(string | undefined)[] | undefined>;
     dependencies?: Record<string, string>;
 };
 

--- a/reports/lib-utils.api.md
+++ b/reports/lib-utils.api.md
@@ -114,6 +114,7 @@ export type AppInitSDKProps = {
     configurations: {
         apiDiscovery?: InitAPIDiscovery;
         apiPriorityList?: string[];
+        apiAllowed?: string[];
         appFetch: UtilsConfig['appFetch'];
         pluginStore: PluginStore;
         wsAppSettings: UtilsConfig['wsAppSettings'];
@@ -269,7 +270,7 @@ export type HrefForLabels = {
 };
 
 // @public (undocumented)
-export type InitAPIDiscovery = (store: Store<unknown, ActionType_2<AnyAction>>, preferenceList?: string[]) => void;
+export type InitAPIDiscovery = (store: Store<unknown, ActionType_2<AnyAction>>, preferenceList?: string[], apiAllowed?: string[]) => void;
 
 // @public
 export const isUtilsConfigSet: () => boolean;


### PR DESCRIPTION
### Description

Another API discovery improvement which allows application to list api it is interested in. API discovery will watch only for these API endpoints and would further limit the number of requests.

### Caveats

Once this is merged and hac-core app starts to send in the list apps might not be able to watch for some resources, unless they specifically list them. We should communicate this change to apps and prepare them for this change (adding the apiAllowed to their config) before we roll this feature fully.

### Example

Usage of this new feature can be seen at https://github.com/openshift/hac-core/pull/119