### PR TITLE
Allow postProcessManifest on manifest object

### DIFF
--- a/packages/lib-core/src/runtime/PluginLoader.ts
+++ b/packages/lib-core/src/runtime/PluginLoader.ts
@@ -119,7 +119,7 @@ export type PluginLoaderOptions = Partial<{
   sharedScope: AnyObject;
 
   /**
-   * Post-process the plugin manifest when fetched over the network.
+   * Post-process the plugin manifest.
    *
    * By default, no post-processing is performed on the manifest.
    */
@@ -226,6 +226,8 @@ export class PluginLoader {
       return;
     }
 
+    manifest = this.options.postProcessManifest(manifest);
+
     try {
       manifest = pluginManifestSchema.strict(true).validateSync(manifest, { abortEarly: false });
     } catch (e) {
@@ -306,7 +308,7 @@ export class PluginLoader {
     const response = await this.options.fetchImpl(manifestURL, { cache: 'no-cache' });
     const responseText = await response.text();
 
-    return this.options.postProcessManifest(JSON.parse(responseText));
+    return JSON.parse(responseText);
   }
 
   /**


### PR DESCRIPTION
It is beneficial to allow the `postProcessManifest` function to run even if a full manifest was passed to the `loadPlugin` function. Sometimes you might need some exception on manifest files, even if they have the correct format.

One exception might be not including the runtime chunk of a module that has disruptive code (react-dom render for example) in that chunk.

cc @vojtechszocs @florkbr 