### PR TITLE
Expose public API functions for api discovery

### DIFF
--- a/packages/lib-utils/src/app/api-discovery/index.ts
+++ b/packages/lib-utils/src/app/api-discovery/index.ts
@@ -5,6 +5,7 @@ import { plural } from 'pluralize';
 import type { Dispatch } from 'redux';
 import { kindToAbbr } from '../../k8s/k8s-resource';
 import type {
+  APIActions,
   APIResourceList,
   DiscoveryResources,
   InitAPIDiscovery,
@@ -17,6 +18,12 @@ import { cacheResources, getCachedResources } from './discovery-cache';
 
 const API_DISCOVERY_INIT_DELAY = 5_000;
 const API_DISCOVERY_REQUEST_BATCH_SIZE = 5;
+
+export const createAPIActions = (dispatch: Dispatch): APIActions => ({
+  setResourcesInFlight: (isInFlight) => dispatch(setResourcesInFlight(isInFlight)),
+  setBatchesInFlight: (isInFlight) => dispatch(setBatchesInFlight(isInFlight)),
+  receivedResources: (resource) => dispatch(receivedResources(resource)),
+});
 
 const pluralizeKind = (kind: string): string => {
   // Use startCase to separate words so the last can be pluralized but remove spaces so as not to humanize

--- a/packages/lib-utils/src/index.ts
+++ b/packages/lib-utils/src/index.ts
@@ -29,7 +29,8 @@ export {
   K8sResourceListResult,
 } from './k8s/k8s-resource';
 export { getK8sResourceURL } from './k8s/k8s-utils';
-export { InitAPIDiscovery, DiscoveryResources } from './types/api-discovery';
+export { createAPIActions, initAPIDiscovery } from './app/api-discovery';
+export { InitAPIDiscovery, DiscoveryResources, APIActions } from './types/api-discovery';
 export {
   K8sModelCommon,
   K8sResourceCommon,

--- a/packages/lib-utils/src/types/api-discovery.ts
+++ b/packages/lib-utils/src/types/api-discovery.ts
@@ -36,3 +36,9 @@ export type DiscoveryResources = {
     };
   };
 };
+
+export type APIActions = {
+  setResourcesInFlight: (isInFlight: boolean) => void;
+  setBatchesInFlight: (isInFlight: boolean) => void;
+  receivedResources: (resource: DiscoveryResources) => void;
+};

--- a/reports/lib-utils.api.md
+++ b/reports/lib-utils.api.md
@@ -7,6 +7,7 @@
 import type { ActionType as ActionType_2 } from 'typesafe-actions';
 import type { AnyAction } from 'redux';
 import type { AnyObject } from '@openshift/dynamic-plugin-sdk';
+import type { Dispatch } from 'redux';
 import { DropdownPosition } from '@patternfly/react-core';
 import type { EitherNotBoth } from '@openshift/dynamic-plugin-sdk';
 import type { IAction } from '@patternfly/react-table';
@@ -106,6 +107,13 @@ export enum ActionType {
     UpdateListFromWS = "updateListFromWS"
 }
 
+// @public (undocumented)
+export type APIActions = {
+    setResourcesInFlight: (isInFlight: boolean) => void;
+    setBatchesInFlight: (isInFlight: boolean) => void;
+    receivedResources: (resource: DiscoveryResources) => void;
+};
+
 // @public
 export const AppInitSDK: React_2.FC<AppInitSDKProps>;
 
@@ -148,6 +156,9 @@ export const commonFetchJSON: {
 
 // @public (undocumented)
 export const commonFetchText: (url: string, requestInit?: RequestInit | undefined, timeout?: number | undefined, isK8sAPIRequest?: boolean | undefined) => Promise<string>;
+
+// @public (undocumented)
+export const createAPIActions: (dispatch: Dispatch) => APIActions;
 
 // @public
 export type DestroyHandler = GenericHandler<unknown | undefined>;
@@ -270,6 +281,9 @@ export type HrefForLabels = {
 
 // @public (undocumented)
 export type InitAPIDiscovery = (store: Store<unknown, ActionType_2<AnyAction>>, preferenceList?: string[]) => void;
+
+// @public (undocumented)
+export const initAPIDiscovery: InitAPIDiscovery;
 
 // @public
 export const isUtilsConfigSet: () => boolean;


### PR DESCRIPTION
### Description

Since apps can use custom api discovery we have to expose functions to dispatch actions to redux store. We can even later down the line change the data passed from application to check if they are sending correct data.