### PR TITLE
Update lib utils to use monorepo common

### DIFF
--- a/packages/eslint-plugin-internal/src/rules/all-bases.js
+++ b/packages/eslint-plugin-internal/src/rules/all-bases.js
@@ -32,6 +32,7 @@ module.exports = {
       {
         includeFiles: 'packages/+(lib-extensions|lib-utils)/src/**',
         excludeFiles: '**/*.+(test|stories).*',
+        excludeModules: ['@monorepo/common'],
       },
     ],
   ],

--- a/packages/lib-utils/api-extractor.json
+++ b/packages/lib-utils/api-extractor.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../api-extractor.json",
-  "mainEntryPointFilePath": "dist/types/index.d.ts",
+  "mainEntryPointFilePath": "dist/types/lib-utils/src/index.d.ts",
+  "bundledPackages": ["@monorepo/common"],
+  "compiler": { "tsconfigFilePath": "tsconfig.api-extractor.json" },
   "apiReport": { "reportFileName": "lib-utils.api.md" },
   "docModel": { "apiJsonFilePath": "dist/api/lib-utils.api.json" }
 }

--- a/packages/lib-utils/src/app/AppInitSDK.tsx
+++ b/packages/lib-utils/src/app/AppInitSDK.tsx
@@ -1,4 +1,5 @@
-import { consoleLogger, PluginStoreProvider } from '@openshift/dynamic-plugin-sdk';
+import { consoleLogger } from '@monorepo/common';
+import { PluginStoreProvider } from '@openshift/dynamic-plugin-sdk';
 import type { PluginStore } from '@openshift/dynamic-plugin-sdk';
 import * as React from 'react';
 import { Provider } from 'react-redux';

--- a/packages/lib-utils/src/app/api-discovery/discovery-cache.ts
+++ b/packages/lib-utils/src/app/api-discovery/discovery-cache.ts
@@ -1,4 +1,4 @@
-import { consoleLogger } from '@openshift/dynamic-plugin-sdk';
+import { consoleLogger } from '@monorepo/common';
 import * as _ from 'lodash-es';
 import { getReferenceForModel } from '../../k8s/k8s-utils';
 import type { DiscoveryResources } from '../../types/api-discovery';

--- a/packages/lib-utils/src/app/api-discovery/index.ts
+++ b/packages/lib-utils/src/app/api-discovery/index.ts
@@ -1,5 +1,5 @@
 import { consoleLogger } from '@monorepo/common';
-import type { AnyObject } from '@openshift/dynamic-plugin-sdk';
+import type { AnyObject } from '@monorepo/common';
 import * as _ from 'lodash-es';
 import { plural } from 'pluralize';
 import type { Dispatch } from 'redux';

--- a/packages/lib-utils/src/app/api-discovery/index.ts
+++ b/packages/lib-utils/src/app/api-discovery/index.ts
@@ -1,5 +1,5 @@
+import { consoleLogger } from '@monorepo/common';
 import type { AnyObject } from '@openshift/dynamic-plugin-sdk';
-import { consoleLogger } from '@openshift/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
 import { plural } from 'pluralize';
 import type { Dispatch } from 'redux';

--- a/packages/lib-utils/src/app/redux/actions/k8s.ts
+++ b/packages/lib-utils/src/app/redux/actions/k8s.ts
@@ -1,4 +1,4 @@
-import { consoleLogger } from '@openshift/dynamic-plugin-sdk';
+import { consoleLogger } from '@monorepo/common';
 import * as _ from 'lodash-es';
 import type { Dispatch } from 'redux';
 import type { ActionType as Action } from 'typesafe-actions';

--- a/packages/lib-utils/src/app/redux/index.ts
+++ b/packages/lib-utils/src/app/redux/index.ts
@@ -1,4 +1,4 @@
-import { consoleLogger } from '@openshift/dynamic-plugin-sdk';
+import { consoleLogger } from '@monorepo/common';
 import * as React from 'react';
 import { useStore } from 'react-redux';
 import type { Store } from 'redux';

--- a/packages/lib-utils/src/app/redux/reducers/k8s/k8s.ts
+++ b/packages/lib-utils/src/app/redux/reducers/k8s/k8s.ts
@@ -1,4 +1,4 @@
-import { consoleLogger } from '@openshift/dynamic-plugin-sdk';
+import { consoleLogger } from '@monorepo/common';
 import { Map as ImmutableMap, fromJS } from 'immutable';
 import * as _ from 'lodash-es';
 import { getReferenceForModel, getNamespacedResources, allModels } from '../../../../k8s/k8s-utils';

--- a/packages/lib-utils/src/components/details-page-header/utils/ActionMenu.tsx
+++ b/packages/lib-utils/src/components/details-page-header/utils/ActionMenu.tsx
@@ -1,4 +1,4 @@
-import type { EitherNotBoth } from '@openshift/dynamic-plugin-sdk';
+import type { EitherNotBoth } from '@monorepo/common';
 import {
   Dropdown,
   DropdownPosition,

--- a/packages/lib-utils/src/components/list-view/ListView.stories.tsx
+++ b/packages/lib-utils/src/components/list-view/ListView.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import type { AnyObject } from '@openshift/dynamic-plugin-sdk';
+import type { AnyObject } from '@monorepo/common';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 import { sortable } from '@patternfly/react-table';

--- a/packages/lib-utils/src/components/list-view/ListView.tsx
+++ b/packages/lib-utils/src/components/list-view/ListView.tsx
@@ -1,4 +1,4 @@
-import type { AnyObject } from '@openshift/dynamic-plugin-sdk';
+import type { AnyObject } from '@monorepo/common';
 import {
   Pagination,
   PaginationVariant,

--- a/packages/lib-utils/src/components/table/VirtualizedTable.tsx
+++ b/packages/lib-utils/src/components/table/VirtualizedTable.tsx
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import type { AnyObject } from '@openshift/dynamic-plugin-sdk';
+import type { AnyObject } from '@monorepo/common';
 import type { IAction } from '@patternfly/react-table';
 import { ActionsColumn, Tbody, Td, Th, Thead, Tr, TableComposable } from '@patternfly/react-table';
 import { AutoSizer, WindowScroller } from '@patternfly/react-virtualized-extension';

--- a/packages/lib-utils/src/components/table/VirtualizedTableBody.tsx
+++ b/packages/lib-utils/src/components/table/VirtualizedTableBody.tsx
@@ -1,4 +1,4 @@
-import type { AnyObject } from '@openshift/dynamic-plugin-sdk';
+import type { AnyObject } from '@monorepo/common';
 import { ActionsColumn, Td as PFTd } from '@patternfly/react-table';
 import type { ICell, SortByDirection, ThProps, TdProps, IAction } from '@patternfly/react-table';
 import { VirtualTableBody } from '@patternfly/react-virtualized-extension';

--- a/packages/lib-utils/src/index.ts
+++ b/packages/lib-utils/src/index.ts
@@ -8,6 +8,9 @@
  * @packageDocumentation
  */
 
+// Common types
+export { AnyObject, EitherNotBoth, Never } from '@monorepo/common';
+
 // Kubernetes utilities
 export { default as AppInitSDK, AppInitSDKProps } from './app/AppInitSDK';
 export { UtilsConfig, isUtilsConfigSet, setUtilsConfig, getUtilsConfig } from './config';

--- a/packages/lib-utils/src/k8s/hooks/k8s-watcher.ts
+++ b/packages/lib-utils/src/k8s/hooks/k8s-watcher.ts
@@ -1,4 +1,4 @@
-import { CustomError } from '@openshift/dynamic-plugin-sdk';
+import { CustomError } from '@monorepo/common';
 import * as _ from 'lodash-es';
 import * as k8sActions from '../../app/redux/actions/k8s';
 import type { K8sModelCommon } from '../../types/k8s';

--- a/packages/lib-utils/src/k8s/hooks/watch-resource-types.ts
+++ b/packages/lib-utils/src/k8s/hooks/watch-resource-types.ts
@@ -1,4 +1,4 @@
-import type { EitherNotBoth } from '@openshift/dynamic-plugin-sdk';
+import type { EitherNotBoth } from '@monorepo/common';
 import type {
   K8sGroupVersionKind,
   K8sResourceCommon,

--- a/packages/lib-utils/src/k8s/k8s-resource.ts
+++ b/packages/lib-utils/src/k8s/k8s-resource.ts
@@ -1,4 +1,4 @@
-import type { AnyObject } from '@openshift/dynamic-plugin-sdk';
+import type { AnyObject } from '@monorepo/common';
 import type { K8sModelCommon, K8sResourceCommon, QueryOptions, Patch } from '../types/k8s';
 import { commonFetchJSON } from '../utils/common-fetch';
 import { getK8sResourceURL } from './k8s-utils';

--- a/packages/lib-utils/src/utils/common-fetch.ts
+++ b/packages/lib-utils/src/utils/common-fetch.ts
@@ -1,4 +1,4 @@
-import { CustomError, applyDefaults, applyOverrides } from '@openshift/dynamic-plugin-sdk';
+import { CustomError, applyDefaults, applyOverrides } from '@monorepo/common';
 import { getUtilsConfig } from '../config';
 
 export type FetchOptionArgs = [

--- a/packages/lib-utils/src/web-socket/WebSocketFactory.ts
+++ b/packages/lib-utils/src/web-socket/WebSocketFactory.ts
@@ -1,4 +1,4 @@
-import { consoleLogger } from '@openshift/dynamic-plugin-sdk';
+import { consoleLogger } from '@monorepo/common';
 import type {
   BulkMessageHandler,
   CloseHandler,

--- a/packages/lib-utils/src/web-socket/types.ts
+++ b/packages/lib-utils/src/web-socket/types.ts
@@ -1,4 +1,4 @@
-import type { AnyObject } from '@openshift/dynamic-plugin-sdk';
+import type { AnyObject } from '@monorepo/common';
 
 /**
  * Configuration that is used to configure WebSockets from a host app perspective.

--- a/packages/lib-utils/tsconfig.api-extractor.json
+++ b/packages/lib-utils/tsconfig.api-extractor.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@monorepo/common": ["dist/types/common/src/index.d.ts"]
+    }
+  }
+}

--- a/packages/lib-utils/tsconfig.json
+++ b/packages/lib-utils/tsconfig.json
@@ -4,5 +4,5 @@
     "outDir": "dist",
     "declarationDir": "types"
   },
-  "include": ["src"]
+  "include": ["src", "../common/src"]
 }

--- a/reports/lib-utils.api.md
+++ b/reports/lib-utils.api.md
@@ -6,10 +6,8 @@
 
 import type { ActionType as ActionType_2 } from 'typesafe-actions';
 import type { AnyAction } from 'redux';
-import type { AnyObject } from '@openshift/dynamic-plugin-sdk';
 import type { Dispatch } from 'redux';
 import { DropdownPosition } from '@patternfly/react-core';
-import type { EitherNotBoth } from '@openshift/dynamic-plugin-sdk';
 import type { IAction } from '@patternfly/react-table';
 import type { ICell } from '@patternfly/react-table';
 import type { Map as Map_2 } from 'immutable';
@@ -106,6 +104,9 @@ export enum ActionType {
     // (undocumented)
     UpdateListFromWS = "updateListFromWS"
 }
+
+// @public
+export type AnyObject = Record<string, unknown>;
 
 // @public (undocumented)
 export type APIActions = {
@@ -210,6 +211,9 @@ export type DiscoveryResources = {
         };
     };
 };
+
+// @public
+export type EitherNotBoth<TypeA, TypeB> = (TypeA & Never<TypeB>) | (TypeB & Never<TypeA>);
 
 // @public (undocumented)
 export type ErrorHandler = GenericHandler<Event>;
@@ -463,6 +467,11 @@ export type MessageDataType = AnyObject | string;
 
 // @public (undocumented)
 export type MessageHandler = GenericHandler<MessageDataType>;
+
+// @public
+export type Never<T> = {
+    [K in keyof T]?: never;
+};
 
 // @public (undocumented)
 export type OpenHandler = GenericHandler<never>;


### PR DESCRIPTION
@vojtechszocs @karelhala FYI. We ran into this issue trying to use `lib-utils` version 1.0.2 in HAC Core. It looks like we missed updated lib-utils to pull the common functions from `@monorepo/common` versus `lib-core`.