### PR TITLE
Allow building plugins without any exposed modules

### DIFF
--- a/packages/lib-core/src/runtime/PluginLoader.ts
+++ b/packages/lib-core/src/runtime/PluginLoader.ts
@@ -107,10 +107,11 @@ export type PluginLoaderOptions = Partial<{
   fixedPluginDependencyResolutions: Record<string, string>;
 
   /**
-   * Shared scope object for initializing `PluginEntryModule` containers.
+   * webpack share scope object for initializing `PluginEntryModule` containers.
    *
    * Host applications built with webpack should use dedicated webpack specific APIs
-   * such as `__webpack_init_sharing__` and `__webpack_share_scopes__`.
+   * such as `__webpack_init_sharing__` and `__webpack_share_scopes__` to initialize
+   * and access this object.
    *
    * Default value: empty object.
    *

--- a/packages/lib-webpack/src/index.ts
+++ b/packages/lib-webpack/src/index.ts
@@ -24,6 +24,7 @@ export {
 export {
   DynamicRemotePlugin,
   DynamicRemotePluginOptions,
+  PluginModuleFederationSettings,
   PluginEntryCallbackSettings,
 } from './webpack/DynamicRemotePlugin';
 

--- a/packages/lib-webpack/src/yup-schemas.ts
+++ b/packages/lib-webpack/src/yup-schemas.ts
@@ -13,6 +13,14 @@ export const pluginBuildMetadataSchema = pluginRuntimeMetadataSchema.shape({
 });
 
 /**
+ * Schema for `PluginModuleFederationSettings` objects.
+ */
+const pluginModuleFederationSettingsSchema = yup.object().required().shape({
+  libraryType: yup.string(),
+  sharedScope: yup.string(),
+});
+
+/**
  * Schema for `PluginEntryCallbackSettings` objects.
  */
 const pluginEntryCallbackSettingsSchema = yup.object().required().shape({
@@ -27,7 +35,7 @@ export const dynamicRemotePluginAdaptedOptionsSchema = yup.object().required().s
   pluginMetadata: pluginBuildMetadataSchema,
   extensions: extensionArraySchema,
   sharedModules: yup.object().required(),
-  moduleFederationLibraryType: yup.string().required(),
+  moduleFederationSettings: pluginModuleFederationSettingsSchema,
   entryCallbackSettings: pluginEntryCallbackSettingsSchema,
   entryScriptFilename: yup.string().required(),
   pluginManifestFilename: yup.string().required(),

--- a/reports/lib-webpack.api.md
+++ b/reports/lib-webpack.api.md
@@ -25,7 +25,7 @@ export type DynamicRemotePluginOptions = Partial<{
     pluginMetadata: string | PluginBuildMetadata;
     extensions: string | EncodedExtension[];
     sharedModules: WebpackSharedObject;
-    moduleFederationLibraryType: string;
+    moduleFederationSettings: PluginModuleFederationSettings;
     entryCallbackSettings: PluginEntryCallbackSettings;
     entryScriptFilename: string;
     pluginManifestFilename: string;
@@ -74,6 +74,12 @@ export type PluginBuildMetadata = PluginRuntimeMetadata & {
 export type PluginEntryCallbackSettings = Partial<{
     name: string;
     pluginID: string;
+}>;
+
+// @public
+export type PluginModuleFederationSettings = Partial<{
+    libraryType: string;
+    sharedScope: string;
 }>;
 
 // @public (undocumented)


### PR DESCRIPTION
This PR fixes an issue described by [CONSOLE-3431](https://issues.redhat.com/browse/CONSOLE-3431).

If a plugin has no exposed modules, e.g. its `exposedModules` object in the plugin metadata is either empty or missing, we should still be able to build the plugin and load it in the host application.

![](https://user-images.githubusercontent.com/648971/215835405-78aef79a-3021-45da-b85d-ff27076d8eb3.png)

There are two reasons to support this use case:
- plugins which only use extensions without code references
- plugins which provide no extensions (for testing purposes)

This PR also adds an option in `DynamicRemotePlugin` to specify the name of webpack share scope object (using `default` as fallback value).

### Breaking changes in `DynamicRemotePlugin`

- removed option `moduleFederationLibraryType`
- added option `moduleFederationSettings` which contains `libraryType` and `sharedScope`

cc @gnunn1