### PR TITLE
Add public sdkVersion property to PluginStore

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@patternfly/react-table": "^4.71.16",
     "@patternfly/react-virtualized-extension": "^4.53.2",
     "@rollup/plugin-commonjs": "^21.0.2",
+    "@rollup/plugin-json": "^5.0.2",
     "@rollup/plugin-node-resolve": "^13.1.1",
     "@rollup/plugin-typescript": "^8.3.0",
     "@storybook/addon-actions": "^6.5.9",

--- a/packages/common/rollup-configs.js
+++ b/packages/common/rollup-configs.js
@@ -2,6 +2,7 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import jsonc from 'jsonc-parser';
@@ -83,6 +84,10 @@ export const tsLibConfig = (pkg, inputFile, format = 'esm') => {
     plugins: [
       nodeResolve(),
       commonjs(),
+      json({
+        compact: true,
+        preferConst: true,
+      }),
       css({
         output: 'dist/index.css',
       }),

--- a/packages/lib-core/src/runtime/PluginStore.ts
+++ b/packages/lib-core/src/runtime/PluginStore.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import type { AnyObject } from '@monorepo/common';
 import { consoleLogger } from '@monorepo/common';
 import * as _ from 'lodash-es';
+import { version as sdkVersion } from '../../package.json';
 import type { Extension, LoadedExtension } from '../types/extension';
 import type {
   PluginRuntimeMetadata,
@@ -53,6 +54,8 @@ export class PluginStore implements PluginStoreInterface {
 
   /** Feature flags used to determine the availability of extensions. */
   private featureFlags: FeatureFlags = {};
+
+  readonly sdkVersion = sdkVersion;
 
   constructor(options: PluginStoreOptions = {}) {
     this.options = {

--- a/packages/lib-core/src/types/store.ts
+++ b/packages/lib-core/src/types/store.ts
@@ -46,6 +46,11 @@ export type FeatureFlags = { [flagName: string]: boolean };
 
 export type PluginStoreInterface = {
   /**
+   * Version of the `@openshift/dynamic-plugin-sdk` package.
+   */
+  readonly sdkVersion: string;
+
+  /**
    * Subscribe to events emitted by the `PluginStore`.
    *
    * See {@link PluginEventType} for information on specific event types.

--- a/packages/sample-app/src/app-minimal.tsx
+++ b/packages/sample-app/src/app-minimal.tsx
@@ -30,6 +30,9 @@ initSharedScope().then(() => {
   pluginStore.setLoader(pluginLoader);
   pluginStore.setFeatureFlags({ TELEMETRY_FLAG: true });
 
+  // eslint-disable-next-line no-console
+  console.info(`Using plugin SDK version ${pluginStore.sdkVersion}`);
+
   render(
     <PluginStoreProvider store={pluginStore}>
       <ErrorBoundary>

--- a/reports/lib-core.api.md
+++ b/reports/lib-core.api.md
@@ -213,6 +213,8 @@ export class PluginStore implements PluginStoreInterface {
     // (undocumented)
     loadPlugin(baseURL: string, manifestNameOrObject?: string | PluginManifest): Promise<void>;
     // (undocumented)
+    readonly sdkVersion: string;
+    // (undocumented)
     setFeatureFlags(newFlags: FeatureFlags): void;
     setLoader(loader: PluginLoader): VoidFunction;
     // (undocumented)
@@ -221,6 +223,7 @@ export class PluginStore implements PluginStoreInterface {
 
 // @public (undocumented)
 export type PluginStoreInterface = {
+    readonly sdkVersion: string;
     subscribe: (eventTypes: PluginEventType[], listener: VoidFunction) => VoidFunction;
     getExtensions: () => LoadedExtension[];
     getPluginInfo: () => PluginInfoEntry[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2599,6 +2599,7 @@ __metadata:
     "@patternfly/react-table": ^4.71.16
     "@patternfly/react-virtualized-extension": ^4.53.2
     "@rollup/plugin-commonjs": ^21.0.2
+    "@rollup/plugin-json": ^5.0.2
     "@rollup/plugin-node-resolve": ^13.1.1
     "@rollup/plugin-typescript": ^8.3.0
     "@storybook/addon-actions": ^6.5.9
@@ -3123,6 +3124,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-json@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@rollup/plugin-json@npm:5.0.2"
+  dependencies:
+    "@rollup/pluginutils": ^5.0.1
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0||^3.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 9b5f90ea311dfcfacf0f38af39bbb1954ea56d6faecdee3d528f73d0e02da96a0706ab21fae0c8eef9bb5d756f6f50b40b5a252ffd9800397012b5bac6764b6f
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-node-resolve@npm:^13.1.1":
   version: 13.1.1
   resolution: "@rollup/plugin-node-resolve@npm:13.1.1"
@@ -3173,6 +3188,22 @@ __metadata:
     estree-walker: ^2.0.1
     picomatch: ^2.2.2
   checksum: 6bc41f22b1a0f1efec3043899e4d3b6b1497b3dea4d94292d8f83b4cf07a1073ecbaedd562a22d11913ff7659f459677b01b09e9598a98936e746780ecc93a12
+  languageName: node
+  linkType: hard
+
+"@rollup/pluginutils@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "@rollup/pluginutils@npm:5.0.2"
+  dependencies:
+    "@types/estree": ^1.0.0
+    estree-walker: ^2.0.2
+    picomatch: ^2.3.1
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0||^3.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: edea15e543bebc7dcac3b0ac8bc7b8e8e6dbd46e2864dbe5dd28072de1fbd5b0e10d545a610c0edaa178e8a7ac432e2a2a52e547ece1308471412caba47db8ce
   languageName: node
   linkType: hard
 
@@ -4760,6 +4791,13 @@ __metadata:
   version: 0.0.39
   resolution: "@types/estree@npm:0.0.39"
   checksum: 412fb5b9868f2c418126451821833414189b75cc6bf84361156feed733e3d92ec220b9d74a89e52722e03d5e241b2932732711b7497374a404fad49087adc248
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@types/estree@npm:1.0.0"
+  checksum: 910d97fb7092c6738d30a7430ae4786a38542023c6302b95d46f49420b797f21619cdde11fa92b338366268795884111c2eb10356e4bd2c8ad5b92941e9e6443
   languageName: node
   linkType: hard
 
@@ -9848,7 +9886,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estree-walker@npm:^2.0.1":
+"estree-walker@npm:^2.0.1, estree-walker@npm:^2.0.2":
   version: 2.0.2
   resolution: "estree-walker@npm:2.0.2"
   checksum: 6151e6f9828abe2259e57f5fd3761335bb0d2ebd76dc1a01048ccee22fabcfef3c0859300f6d83ff0d1927849368775ec5a6d265dde2f6de5a1be1721cd94efc


### PR DESCRIPTION
This PR gives runtime consumers of `PluginStore` the ability to determine the version of `@openshift/dynamic-plugin-sdk` package that was used in their build.

For example, host applications can print the plugin SDK version at startup for better diagnostics.