### PR TITLE
[RHCLOUD-21699] Update watches on workspace change

### DIFF
--- a/packages/lib-utils/src/app/redux/reducers/k8s/k8s.ts
+++ b/packages/lib-utils/src/app/redux/reducers/k8s/k8s.ts
@@ -89,7 +89,10 @@ const loadList = (oldList: any, resources: K8sResourceCommon[]) => {
 export const sdkK8sReducer = (state: K8sState, action: K8sAction): K8sState => {
   if (!state) {
     return fromJS({
-      RESOURCES: { inFlight: false, models: ImmutableMap<string, K8sModelCommon>() },
+      RESOURCES: {
+        inFlight: false,
+        models: ImmutableMap<string, K8sModelCommon>(),
+      },
     });
   }
 

--- a/packages/lib-utils/src/hooks/useWorkspace.test.tsx
+++ b/packages/lib-utils/src/hooks/useWorkspace.test.tsx
@@ -1,5 +1,8 @@
 import { renderHook } from '@testing-library/react-hooks/native';
+import React from 'react';
 import TestRenderer from 'react-test-renderer';
+import WorkspaceContext from '../utils/WorkspaceContext';
+import { workspaceState } from '../utils/workspaceState';
 import { useWorkspace } from './useWorkspace';
 
 const { act } = TestRenderer;
@@ -22,7 +25,10 @@ describe('useWorkspace', () => {
   });
 
   test('an unset workspace should return null', () => {
-    const { result } = renderHook(() => useWorkspace());
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <WorkspaceContext.Provider value={workspaceState()}>{children}</WorkspaceContext.Provider>
+    );
+    const { result } = renderHook(() => useWorkspace(), { wrapper });
     const [data, setter] = result.current;
 
     expect(data).toBeNull();
@@ -31,7 +37,10 @@ describe('useWorkspace', () => {
 
   test('a set workspace should return the activeWorkspace', () => {
     localStorage.setItem(WORKSPACE_KEY, 'platform-experience');
-    const { result } = renderHook(() => useWorkspace());
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <WorkspaceContext.Provider value={workspaceState()}>{children}</WorkspaceContext.Provider>
+    );
+    const { result } = renderHook(() => useWorkspace(), { wrapper });
     const [data, setter] = result.current;
 
     expect(data).toBe('platform-experience');
@@ -40,7 +49,10 @@ describe('useWorkspace', () => {
 
   test('updating workspace should return the activeWorkspace', () => {
     localStorage.setItem(WORKSPACE_KEY, 'platform-experience');
-    const { result } = renderHook(() => useWorkspace());
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <WorkspaceContext.Provider value={workspaceState()}>{children}</WorkspaceContext.Provider>
+    );
+    const { result } = renderHook(() => useWorkspace(), { wrapper });
     const [data, setter] = result.current;
 
     expect(data).toBe('platform-experience');
@@ -53,7 +65,10 @@ describe('useWorkspace', () => {
 
   test('clearing localStorage should return null', () => {
     localStorage.setItem(WORKSPACE_KEY, 'platform-experience');
-    const { result } = renderHook(() => useWorkspace());
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <WorkspaceContext.Provider value={workspaceState()}>{children}</WorkspaceContext.Provider>
+    );
+    const { result } = renderHook(() => useWorkspace(), { wrapper });
     const [data, setter] = result.current;
 
     expect(data).toBe('platform-experience');

--- a/packages/lib-utils/src/hooks/useWorkspace.ts
+++ b/packages/lib-utils/src/hooks/useWorkspace.ts
@@ -1,6 +1,8 @@
 import { consoleLogger } from '@openshift/dynamic-plugin-sdk';
-import { useState } from 'react';
-import { getActiveWorkspace, setActiveWorkspace } from '../k8s/k8s-utils';
+import { useContext, useEffect, useReducer } from 'react';
+import { setActiveWorkspaceLocalStorage } from '../k8s/k8s-utils';
+import WorkspaceContext from '../utils/WorkspaceContext';
+import { UpdateEvents } from '../utils/workspaceState';
 
 /**
  * Hook that retrieves the active workspace from localStorage. The key for the active workspace is
@@ -18,34 +20,34 @@ import { getActiveWorkspace, setActiveWorkspace } from '../k8s/k8s-utils';
  * ```
  */
 export const useWorkspace = () => {
+  const { subscribe, unsubscribe, getState, setWorkspaceContext } = useContext(WorkspaceContext);
+  // There isn't any other way around this for now, but this is an active anti-pattern. We need to reRender the page to
+  // get the websocket to watch the new workspace on change. This is considered tech-debt and is actively discouraged.
+  // https://reactjs.org/docs/hooks-faq.html#is-there-something-like-forceupdate
+  const [, forceRender] = useReducer((count) => count + 1, 0);
+
   // All returns will be valid workspaces or null. Since there is no "default" workspace,
   // a null value means that one needs to be set. Returning a default or empty string will
   // break the model
-  const [workspace, setWorkspace] = useState(() => {
-    if (typeof window === 'undefined') {
-      return null;
-    }
-
-    try {
-      // get the activeWorkspace under that key if set, otherwise return null.
-      return getActiveWorkspace();
-    } catch (error) {
-      consoleLogger.error(`Failed to get activeWorkspace due to: ${error}`);
-      return null;
-    }
-  });
+  const workspace = getState().activeWorkspace;
 
   const setActive = (newWorkspace: string) => {
     try {
-      setWorkspace(newWorkspace);
-      // Save to local storage using helper tools
       if (typeof window !== 'undefined') {
-        setActiveWorkspace(newWorkspace);
+        setActiveWorkspaceLocalStorage(newWorkspace);
+        setWorkspaceContext(newWorkspace);
       }
     } catch (error) {
       consoleLogger.error(`Failed to get activeWorkspace due to: ${error}`);
     }
   };
+
+  useEffect(() => {
+    const subsId = subscribe(UpdateEvents.activeWorkspace, forceRender);
+    return () => {
+      unsubscribe(subsId, UpdateEvents.activeWorkspace);
+    };
+  }, [subscribe, unsubscribe]);
 
   return [workspace, setActive] as const;
 };

--- a/packages/lib-utils/src/index.ts
+++ b/packages/lib-utils/src/index.ts
@@ -11,6 +11,8 @@
 // Kubernetes utilities
 export { default as AppInitSDK, AppInitSDKProps } from './app/AppInitSDK';
 export { useWorkspace } from './hooks/useWorkspace';
+export { default as WorkspaceContext } from './utils/WorkspaceContext';
+export { default as WorkspaceProvider } from './utils/WorkspaceProvider';
 export { UtilsConfig, isUtilsConfigSet, setUtilsConfig, getUtilsConfig } from './config';
 export { commonFetch, commonFetchText, commonFetchJSON } from './utils/common-fetch';
 export {
@@ -29,7 +31,11 @@ export {
   K8sResourceListOptions,
   K8sResourceListResult,
 } from './k8s/k8s-resource';
-export { getK8sResourceURL, getActiveWorkspace, setActiveWorkspace } from './k8s/k8s-utils';
+export {
+  getK8sResourceURL,
+  getActiveWorkspace,
+  setActiveWorkspaceLocalStorage,
+} from './k8s/k8s-utils';
 export { createAPIActions, initAPIDiscovery } from './app/api-discovery';
 export { InitAPIDiscovery, DiscoveryResources, APIActions } from './types/api-discovery';
 export {

--- a/packages/lib-utils/src/k8s/hooks/useK8sWatchResource.ts
+++ b/packages/lib-utils/src/k8s/hooks/useK8sWatchResource.ts
@@ -5,6 +5,7 @@ import * as k8sActions from '../../app/redux/actions/k8s';
 import { getReduxIdPayload } from '../../app/redux/reducers/k8s/selector';
 import type { K8sResourceCommon } from '../../types/k8s';
 import type { SDKStoreState } from '../../types/redux';
+import WorkspaceContext from '../../utils/WorkspaceContext';
 import type { WebSocketOptions } from '../../web-socket/types';
 import { getWatchData, getReduxData, NoModelError } from './k8s-watcher';
 import { useDeepCompareMemoize } from './useDeepCompareMemoize';
@@ -35,6 +36,8 @@ export const useK8sWatchResource = <R extends K8sResourceCommon | K8sResourceCom
   initResource: WatchK8sResource | null,
   options?: Partial<WebSocketOptions & RequestInit & { wsPrefix?: string; pathPrefix?: string }>,
 ): WatchK8sResult<R> => {
+  const workspaceContext = React.useContext(WorkspaceContext);
+  const workspace = workspaceContext.getState().activeWorkspace;
   const withFallback: WatchK8sResource = initResource || { kind: NOT_A_VALUE };
   const resource = useDeepCompareMemoize(withFallback, true);
   const modelsLoaded = useModelsLoaded();
@@ -57,7 +60,7 @@ export const useK8sWatchResource = <R extends K8sResourceCommon | K8sResourceCom
         dispatch(k8sActions.stopK8sWatch(watchData.id));
       }
     };
-  }, [dispatch, watchData]);
+  }, [dispatch, watchData, workspace]);
 
   const resourceK8s = useSelector<SDKStoreState, unknown>((state) =>
     watchData ? getReduxIdPayload(state, watchData.id) : null,

--- a/packages/lib-utils/src/k8s/k8s-utils.ts
+++ b/packages/lib-utils/src/k8s/k8s-utils.ts
@@ -27,7 +27,7 @@ export function getActiveWorkspace() {
 /**
  * @param workspace - the string name of the workspace you wish to set as active
  */
-export function setActiveWorkspace(workspace: string) {
+export function setActiveWorkspaceLocalStorage(workspace: string) {
   localStorage.setItem(ACTIVE_WORKSPACE_KEY, workspace);
 }
 

--- a/packages/lib-utils/src/utils/WorkspaceContext.ts
+++ b/packages/lib-utils/src/utils/WorkspaceContext.ts
@@ -1,6 +1,16 @@
 import { createContext } from 'react';
 import type { workspaceState } from './workspaceState';
 
+/**
+ *
+ * The WorkspaceContext is a context for the `workspaceState`. It is used to access the methods
+ * and data used to implement an `activeWorkspace`.
+ *
+ * @example
+ * ``` ts
+ * const { subscribe, unsubscribe, getState, setWorkspaceContext } = useContext(WorkspaceContext);
+ * ```
+ */
 const WorkspaceContext = createContext<ReturnType<typeof workspaceState>>({
   update: () => undefined,
   setWorkspaceContext: () => undefined,

--- a/packages/lib-utils/src/utils/WorkspaceContext.ts
+++ b/packages/lib-utils/src/utils/WorkspaceContext.ts
@@ -1,0 +1,15 @@
+import { createContext } from 'react';
+import type { workspaceState } from './workspaceState';
+
+const WorkspaceContext = createContext<ReturnType<typeof workspaceState>>({
+  update: () => undefined,
+  setWorkspaceContext: () => undefined,
+  subscribe: () => '',
+  unsubscribe: () => undefined,
+  getState: () => ({
+    subscribtions: {},
+    activeWorkspace: null,
+  }),
+});
+
+export default WorkspaceContext;

--- a/packages/lib-utils/src/utils/WorkspaceProvider.tsx
+++ b/packages/lib-utils/src/utils/WorkspaceProvider.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import WorkspaceContext from './WorkspaceContext';
+import { workspaceState } from './workspaceState';
+
+const WorkspaceProvider: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
+  const state = React.useMemo(() => workspaceState(), []);
+  return <WorkspaceContext.Provider value={state}>{children}</WorkspaceContext.Provider>;
+};
+
+export default WorkspaceProvider;

--- a/packages/lib-utils/src/utils/WorkspaceProvider.tsx
+++ b/packages/lib-utils/src/utils/WorkspaceProvider.tsx
@@ -2,6 +2,20 @@ import React from 'react';
 import WorkspaceContext from './WorkspaceContext';
 import { workspaceState } from './workspaceState';
 
+/**
+ * Context for passing through the activeWorkspace. The context provides the active value
+ * to the `useWorkspace` hook. This context maintains the state of the activeWorkspace while 
+ * providing a publish/subscribe model to refresh the kubernetes watches on a workspace change.
+ * 
+ * @returns A full context with the activeWorkspace's state and internal update methods
+ * 
+ * @example 
+ * ``` ts
+ *  <WorkspaceProvider>
+      <App />
+    </WorkspaceProvider>
+ * ```
+ */
 const WorkspaceProvider: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   const state = React.useMemo(() => workspaceState(), []);
   return <WorkspaceContext.Provider value={state}>{children}</WorkspaceContext.Provider>;

--- a/packages/lib-utils/src/utils/workspaceState.ts
+++ b/packages/lib-utils/src/utils/workspaceState.ts
@@ -1,0 +1,76 @@
+import { v4 as uuidv4 } from 'uuid';
+
+const WORKSPACE_KEY = 'sdk/active-workspace';
+export type WorkspaceContextState = {
+  activeWorkspace: string | null;
+};
+
+export enum UpdateEvents {
+  activeWorkspace = 'activeWorkspace',
+}
+
+export const workspaceState = () => {
+  let state: WorkspaceContextState = {
+    activeWorkspace: localStorage.getItem(WORKSPACE_KEY),
+  };
+
+  // registry of all subscribers (hooks)
+  const subscriptions: {
+    [key in UpdateEvents]: {
+      [id: string]: () => void;
+    };
+  } = {
+    activeWorkspace: {},
+  };
+
+  // add subscriber (hook) to registry
+  function subscribe(event: UpdateEvents, onUpdate: () => void) {
+    const id = uuidv4();
+    // const id = `${Date.now()}${Math.random()}`;
+    subscriptions[event][id] = onUpdate;
+    // trigger initial update to get the initial data
+    onUpdate();
+    return id;
+  }
+
+  // remove subscriber from registry
+  function unsubscribe(id: string, event: UpdateEvents) {
+    delete subscriptions[event][id];
+  }
+
+  // update state attribute and push data to subscribers
+  function update(event: UpdateEvents, attributes: Partial<WorkspaceContextState>) {
+    state = {
+      ...state,
+      ...attributes,
+    };
+    const updateSubscriptions = Object.values(subscriptions[event]);
+    if (updateSubscriptions.length === 0) {
+      return;
+    }
+
+    // update the subscribed clients
+    updateSubscriptions.forEach((onUpdate) => {
+      onUpdate();
+    });
+  }
+
+  function setWorkspaceContext(workspace: string | null) {
+    update(UpdateEvents.activeWorkspace, { activeWorkspace: workspace });
+  }
+
+  function getState() {
+    return state;
+  }
+
+  // public state manager interface
+  return {
+    getState,
+    setWorkspaceContext,
+    subscribe,
+    unsubscribe,
+    update,
+  };
+};
+
+export default workspaceState;

--- a/reports/lib-utils.api.md
+++ b/reports/lib-utils.api.md
@@ -4,9 +4,12 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import type { ActionType as ActionType_2 } from 'typesafe-actions';
 import type { AnyAction } from 'redux';
 import type { AnyObject } from '@openshift/dynamic-plugin-sdk';
+import { Context } from 'react';
 import type { Dispatch } from 'redux';
 import { DropdownPosition } from '@patternfly/react-core';
 import type { EitherNotBoth } from '@openshift/dynamic-plugin-sdk';
@@ -667,7 +670,7 @@ export type Selector = Partial<{
 }>;
 
 // @public (undocumented)
-export function setActiveWorkspace(workspace: string): void;
+export function setActiveWorkspaceLocalStorage(workspace: string): void;
 
 // @public
 export const setUtilsConfig: (c: UtilsConfig) => void;
@@ -856,5 +859,22 @@ export type WithRouterProps = {
     navigate?: ReturnType<typeof useNavigate>;
     location?: ReturnType<typeof useLocation>;
 };
+
+// @public (undocumented)
+export const WorkspaceContext: Context<    {
+getState: () => WorkspaceContextState;
+setWorkspaceContext: (workspace: string | null) => void;
+subscribe: (event: UpdateEvents, onUpdate: () => void) => string;
+unsubscribe: (id: string, event: UpdateEvents) => void;
+update: (event: UpdateEvents, attributes: Partial<WorkspaceContextState>) => void;
+}>;
+
+// @public (undocumented)
+export const WorkspaceProvider: React_3.FC<React_3.PropsWithChildren<unknown>>;
+
+// Warnings were encountered during analysis:
+//
+// dist/types/utils/WorkspaceContext.d.ts:3:5 - (ae-forgotten-export) The symbol "WorkspaceContextState" needs to be exported by the entry point index.d.ts
+// dist/types/utils/WorkspaceContext.d.ts:5:5 - (ae-forgotten-export) The symbol "UpdateEvents" needs to be exported by the entry point index.d.ts
 
 ```

--- a/reports/lib-utils.api.md
+++ b/reports/lib-utils.api.md
@@ -860,7 +860,7 @@ export type WithRouterProps = {
     location?: ReturnType<typeof useLocation>;
 };
 
-// @public (undocumented)
+// @public
 export const WorkspaceContext: Context<    {
 getState: () => WorkspaceContextState;
 setWorkspaceContext: (workspace: string | null) => void;
@@ -869,12 +869,12 @@ unsubscribe: (id: string, event: UpdateEvents) => void;
 update: (event: UpdateEvents, attributes: Partial<WorkspaceContextState>) => void;
 }>;
 
-// @public (undocumented)
+// @public
 export const WorkspaceProvider: React_3.FC<React_3.PropsWithChildren<unknown>>;
 
 // Warnings were encountered during analysis:
 //
-// dist/types/utils/WorkspaceContext.d.ts:3:5 - (ae-forgotten-export) The symbol "WorkspaceContextState" needs to be exported by the entry point index.d.ts
-// dist/types/utils/WorkspaceContext.d.ts:5:5 - (ae-forgotten-export) The symbol "UpdateEvents" needs to be exported by the entry point index.d.ts
+// dist/types/utils/WorkspaceContext.d.ts:13:5 - (ae-forgotten-export) The symbol "WorkspaceContextState" needs to be exported by the entry point index.d.ts
+// dist/types/utils/WorkspaceContext.d.ts:15:5 - (ae-forgotten-export) The symbol "UpdateEvents" needs to be exported by the entry point index.d.ts
 
 ```


### PR DESCRIPTION
In order to refresh the watches on each resource when a workspace changes, we've added a Provider and publish/subscribe model to the workspace switcher. On a workspace change, the `watchK8sResources` hooks will refire to update the websocket connections to the new URIs.

We will need an additional PR to hac-core to actually initialize the provider.

If this approach gets the full 👍 , I'll update the tests, docs, and remove it from Draft. 