### PR TITLE
Add support for custom plugin properties

### DIFF
--- a/packages/common/src/types/common.ts
+++ b/packages/common/src/types/common.ts
@@ -8,16 +8,6 @@
 export type AnyObject = Record<string, unknown>;
 
 /**
- * The type `Function` doesn't provide enough type safety.
- *
- * Use the `AnyFunction` type for arbitrary functions whose signature is unknown.
- *
- * @see https://github.com/typescript-eslint/typescript-eslint/issues/1896
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyFunction = (...args: any) => any;
-
-/**
  * Replace existing direct properties of `T` with ones declared in `R`.
  */
 export type ReplaceProperties<T, R> = {

--- a/packages/lib-core/CHANGELOG.md
+++ b/packages/lib-core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.1 - 2023-01-27
 
-- Call postProcessManifest regardless if manifest is provided as a custom object ([#190])
+- Call `postProcessManifest` regardless of plugin manifest origin ([#190])
 
 ## 2.0.0 - 2023-01-23
 

--- a/packages/lib-core/src/runtime/PluginStore.ts
+++ b/packages/lib-core/src/runtime/PluginStore.ts
@@ -155,8 +155,8 @@ export class PluginStore implements PluginStoreInterface {
 
     Array.from(this.loadedPlugins.entries()).forEach(([pluginName, plugin]) => {
       entries.push({
-        pluginName,
         status: 'loaded',
+        pluginName,
         metadata: plugin.metadata,
         enabled: plugin.enabled,
         disableReason: plugin.disableReason,
@@ -165,8 +165,8 @@ export class PluginStore implements PluginStoreInterface {
 
     Array.from(this.failedPlugins.entries()).forEach(([pluginName, plugin]) => {
       entries.push({
-        pluginName,
         status: 'failed',
+        pluginName,
         errorMessage: plugin.errorMessage,
         errorCause: plugin.errorCause,
       });
@@ -284,7 +284,12 @@ export class PluginStore implements PluginStoreInterface {
     const buildHash = manifest.buildHash ?? uuidv4();
     const reload = this.loadedPlugins.has(pluginName) || this.failedPlugins.has(pluginName);
 
-    const metadata: PluginRuntimeMetadata = _.pick(manifest, ['name', 'version', 'dependencies']);
+    const metadata: PluginRuntimeMetadata = _.pick(manifest, [
+      'name',
+      'version',
+      'dependencies',
+      'customProperties',
+    ]);
 
     const processedExtensions = this.processExtensions(
       pluginName,

--- a/packages/lib-core/src/types/extension.ts
+++ b/packages/lib-core/src/types/extension.ts
@@ -15,7 +15,6 @@ export type Extension<TType extends string = string, TProperties extends AnyObje
 export type LoadedExtension<TExtension extends Extension = Extension> = TExtension & {
   pluginName: string;
   uid: string;
-  [customProperty: string]: unknown;
 };
 
 export type ExtensionPredicate<TExtension extends Extension> = (e: Extension) => e is TExtension;

--- a/packages/lib-core/src/types/plugin.ts
+++ b/packages/lib-core/src/types/plugin.ts
@@ -1,3 +1,4 @@
+import type { AnyObject } from '@monorepo/common';
 import type { Extension, LoadedExtension } from './extension';
 import type { PluginEntryModule } from './runtime';
 
@@ -7,6 +8,7 @@ export type PluginRuntimeMetadata = {
   name: string;
   version: string;
   dependencies?: Record<string, string>;
+  customProperties?: AnyObject;
 };
 
 export type PluginManifest = PluginRuntimeMetadata & {

--- a/packages/lib-core/src/types/store.ts
+++ b/packages/lib-core/src/types/store.ts
@@ -1,6 +1,6 @@
 import type { AnyObject } from '@monorepo/common';
 import type { LoadedExtension } from './extension';
-import type { LoadedPlugin, FailedPlugin, PluginManifest } from './plugin';
+import type { PluginManifest, LoadedPlugin, FailedPlugin } from './plugin';
 
 export enum PluginEventType {
   /**
@@ -31,13 +31,13 @@ export enum PluginEventType {
 }
 
 export type LoadedPluginInfoEntry = {
-  pluginName: string;
   status: 'loaded';
+  pluginName: string;
 } & Pick<LoadedPlugin, 'metadata' | 'enabled' | 'disableReason'>;
 
 export type FailedPluginInfoEntry = {
-  pluginName: string;
   status: 'failed';
+  pluginName: string;
 } & Pick<FailedPlugin, 'errorMessage' | 'errorCause'>;
 
 export type PluginInfoEntry = LoadedPluginInfoEntry | FailedPluginInfoEntry;

--- a/packages/lib-core/src/yup-schemas.ts
+++ b/packages/lib-core/src/yup-schemas.ts
@@ -1,3 +1,5 @@
+// TODO(vojtech): suppress false positive https://github.com/jsx-eslint/eslint-plugin-react/pull/3326
+/* eslint-disable react/forbid-prop-types */
 import * as yup from 'yup';
 import type { PluginRegistrationMethod } from './types/plugin';
 
@@ -97,9 +99,8 @@ export const pluginRuntimeMetadataSchema = yup.object().required().shape({
   name: pluginNameSchema,
   version: semverStringSchema,
   // TODO(vojtech): Yup lacks native support for map-like structures with arbitrary keys
-  // TODO(vojtech): suppress false positive https://github.com/jsx-eslint/eslint-plugin-react/pull/3326
-  // eslint-disable-next-line react/forbid-prop-types
   dependencies: yup.object(),
+  customProperties: yup.object(),
 });
 
 /**

--- a/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
+++ b/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
@@ -255,6 +255,7 @@ export class DynamicRemotePlugin implements WebpackPluginInstance {
       name: this.pluginMetadata.name,
       version: this.pluginMetadata.version,
       dependencies: this.pluginMetadata.dependencies,
+      customProperties: this.pluginMetadata.customProperties,
       extensions: this.extensions,
       registrationMethod: jsonp ? 'callback' : 'custom',
     }).apply(compiler);

--- a/packages/sample-app/package.json
+++ b/packages/sample-app/package.json
@@ -25,6 +25,7 @@
     "css-minimizer-webpack-plugin": "^3.4.1",
     "html-webpack-plugin": "^5.5.0",
     "http-server": "^14.1.0",
+    "lodash-es": "^4.17.21",
     "mini-css-extract-plugin": "^2.6.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/packages/sample-app/src/components/app-minimal/MinimalAppPage.tsx
+++ b/packages/sample-app/src/components/app-minimal/MinimalAppPage.tsx
@@ -4,12 +4,16 @@ import { isModelFeatureFlag, isTelemetryListener } from '@openshift/dynamic-plug
 import {
   Card,
   CardBody,
-  CardTitle,
   Flex,
   FlexItem,
   Gallery,
   GalleryItem,
+  Tooltip,
 } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+// eslint-disable-next-line camelcase
+import { global_info_color_100 } from '@patternfly/react-tokens';
+import * as _ from 'lodash-es';
 import * as React from 'react';
 import FeatureFlagTable from '../common/FeatureFlagTable';
 import PluginInfoTable from '../common/PluginInfoTable';
@@ -23,8 +27,16 @@ const ExtensionGallery: React.FC<ExtensionGalleryProps> = ({ extensions }) => (
     {extensions.map((e) => (
       <GalleryItem key={e.uid}>
         <Card isCompact>
-          <CardTitle>{e.type}</CardTitle>
-          <CardBody>{e.uid}</CardBody>
+          <CardBody>
+            <Flex direction={{ default: 'row' }} spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>{e.type}</FlexItem>
+              <FlexItem>
+                <Tooltip content={_.truncate(e.uid)}>
+                  <InfoCircleIcon color={global_info_color_100.var} />
+                </Tooltip>
+              </FlexItem>
+            </Flex>
+          </CardBody>
         </Card>
       </GalleryItem>
     ))}

--- a/packages/sample-app/src/components/common/FeatureFlagTable.tsx
+++ b/packages/sample-app/src/components/common/FeatureFlagTable.tsx
@@ -8,18 +8,14 @@ const columnNames = {
   featureFlags: 'Feature flags',
 };
 
+const actionLabels = {
+  enable: 'Enable',
+  disable: 'Disable',
+};
+
 const FeatureFlagTable: React.FC = () => {
   const flagName = 'TELEMETRY_FLAG';
   const [flag, setFlag] = useFeatureFlag(flagName);
-
-  const [actionButtonLabel, setActionButtonLabel] = React.useState<string>(
-    flag ? 'Disable' : 'Enable',
-  );
-
-  const toggleFeatureFlag = () => {
-    setFlag(!flag);
-    setActionButtonLabel(!flag ? 'Disable' : 'Enable');
-  };
 
   return (
     <TableComposable variant="compact">
@@ -27,16 +23,15 @@ const FeatureFlagTable: React.FC = () => {
         <Tr>
           <Th>{columnNames.featureFlags}</Th>
           <Th>{columnNames.action}</Th>
-          <Td />
         </Tr>
       </Thead>
       <Tbody>
         <Tr>
           <Td dataLabel={columnNames.featureFlags}>{flagName}</Td>
-          <Td dataLabel={columnNames.action}>
+          <Td dataLabel={columnNames.action} modifier="fitContent">
             <TableText>
-              <Button variant="secondary" onClick={() => toggleFeatureFlag()}>
-                {actionButtonLabel}
+              <Button variant="secondary" onClick={() => setFlag(!flag)}>
+                {flag ? actionLabels.disable : actionLabels.enable}
               </Button>
             </TableText>
           </Td>

--- a/packages/sample-plugin/plugin-metadata.json
+++ b/packages/sample-plugin/plugin-metadata.json
@@ -6,5 +6,8 @@
   },
   "exposedModules": {
     "telemetryListener": "./src/telemetry-listener"
+  },
+  "customProperties": {
+    "test": true
   }
 }

--- a/reports/lib-core.api.md
+++ b/reports/lib-core.api.md
@@ -70,8 +70,8 @@ export type FailedPlugin = {
 
 // @public (undocumented)
 export type FailedPluginInfoEntry = {
-    pluginName: string;
     status: 'failed';
+    pluginName: string;
 } & Pick<FailedPlugin, 'errorMessage' | 'errorCause'>;
 
 // @public (undocumented)
@@ -83,7 +83,6 @@ export type FeatureFlags = {
 export type LoadedExtension<TExtension extends Extension = Extension> = TExtension & {
     pluginName: string;
     uid: string;
-    [customProperty: string]: unknown;
 };
 
 // @public (undocumented)
@@ -97,8 +96,8 @@ export type LoadedPlugin = {
 
 // @public (undocumented)
 export type LoadedPluginInfoEntry = {
-    pluginName: string;
     status: 'loaded';
+    pluginName: string;
 } & Pick<LoadedPlugin, 'metadata' | 'enabled' | 'disableReason'>;
 
 // @public (undocumented)
@@ -190,6 +189,7 @@ export type PluginRuntimeMetadata = {
     name: string;
     version: string;
     dependencies?: Record<string, string>;
+    customProperties?: AnyObject;
 };
 
 // @public

--- a/reports/lib-webpack.api.md
+++ b/reports/lib-webpack.api.md
@@ -87,6 +87,7 @@ export type PluginRuntimeMetadata = {
     name: string;
     version: string;
     dependencies?: Record<string, string>;
+    customProperties?: AnyObject;
 };
 
 // @public

--- a/yarn.lock
+++ b/yarn.lock
@@ -2695,6 +2695,7 @@ __metadata:
     css-minimizer-webpack-plugin: ^3.4.1
     html-webpack-plugin: ^5.5.0
     http-server: ^14.1.0
+    lodash-es: ^4.17.21
     mini-css-extract-plugin: ^2.6.0
     react: ^17.0.2
     react-dom: ^17.0.2


### PR DESCRIPTION
This PR allows plugins to pass custom properties to host applications.

For example, [OpenShift Console dynamic plugins](https://github.com/openshift/console/tree/master/frontend/packages/console-dynamic-plugin-sdk) can specify additional properties such as `displayName`, `description` and `disableStaticPlugins` within their plugin metadata.

This PR adds new `customProperties` field to contain all such application or environment specific properties.

At runtime, these properties can be accessed via loaded plugin info entries, for example:
```ts
const infoEntries = usePluginInfo();

infoEntries.forEach((entry) => {
  if (entry.status === 'loaded') {
    // do something with entry.metadata.customProperties
  }
});
```

![](https://user-images.githubusercontent.com/648971/217343082-ac12302d-ee84-4257-8bbf-ffea9d6da5a4.png)

### Other code changes
- update `PluginInfoTable` component - add action dropdown to log custom properties
- simplify `FeatureFlagTable` component - remove unnecessary `React.useState` call
- remove `AnyFunction` common type since it seems to be unused
