### PR TITLE
Add technical compatibility with React 18

### DIFF
--- a/docs/react-version.md
+++ b/docs/react-version.md
@@ -1,0 +1,24 @@
+# React Version Requirement
+
+Tools provided by dynamic plugin SDK are [React](https://reactjs.org/) focused.
+
+If your host application or plugin uses [PatternFly](https://www.patternfly.org/), you should
+use a React version that is officially supported by your PatternFly major version.
+
+Host applications will typically provide React specific modules such as `react` and `react-dom`
+to their plugins via webpack shared scope object.
+
+## PatternFly 4 example
+
+The [manifest][pf-react-core-4.276.6] for `@patternfly/react-core` package version `4.276.6`
+contains the following peer dependencies:
+
+```
+"react": "^16.8 || ^17 || ^18",
+"react-dom": "^16.8 || ^17 || ^18"
+```
+
+This combines officially supported React versions (`^16.8 || ^17`) and newer React versions for
+the sake of technical compatibility (`^18`) into a single version range.
+
+[pf-react-core-4.276.6]: https://github.com/patternfly/patternfly-react/blob/%40patternfly/react-core%404.276.6/packages/react-core/package.json

--- a/packages/lib-core/package.json
+++ b/packages/lib-core/package.json
@@ -25,7 +25,7 @@
     "api-extractor": "yarn run -T api-extractor -c $INIT_CWD/api-extractor.json"
   },
   "peerDependencies": {
-    "react": "^17.0.2"
+    "react": "^17 || ^18"
   },
   "dependencies": {
     "lodash-es": "^4.17.21",

--- a/packages/lib-extensions/package.json
+++ b/packages/lib-extensions/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@openshift/dynamic-plugin-sdk": "^2.0.0",
-    "react": "^17.0.2",
+    "react": "^17 || ^18",
     "react-redux": "^7.2.2",
     "react-router": "^5.2.1",
     "redux": "^4.1.2"

--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -32,7 +32,7 @@
     "@patternfly/react-styles": "^4.52.16",
     "@patternfly/react-table": "^4.71.16",
     "@patternfly/react-virtualized-extension": "^4.53.2",
-    "react": "^17.0.2",
+    "react": "^17 || ^18",
     "react-redux": "^7.2.2",
     "react-router": "^5.2.1",
     "react-router-dom": "^6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2798,7 +2798,7 @@ __metadata:
   resolution: "@openshift/dynamic-plugin-sdk-extensions@portal:../lib-extensions::locator=%40monorepo%2Fsample-app%40workspace%3Apackages%2Fsample-app"
   peerDependencies:
     "@openshift/dynamic-plugin-sdk": ^2.0.0
-    react: ^17.0.2
+    react: ^17 || ^18
     react-redux: ^7.2.2
     react-router: ^5.2.1
     redux: ^4.1.2
@@ -2817,7 +2817,7 @@ __metadata:
   resolution: "@openshift/dynamic-plugin-sdk-extensions@portal:../lib-extensions::locator=%40monorepo%2Fsample-plugin%40workspace%3Apackages%2Fsample-plugin"
   peerDependencies:
     "@openshift/dynamic-plugin-sdk": ^2.0.0
-    react: ^17.0.2
+    react: ^17 || ^18
     react-redux: ^7.2.2
     react-router: ^5.2.1
     redux: ^4.1.2
@@ -2836,7 +2836,7 @@ __metadata:
   resolution: "@openshift/dynamic-plugin-sdk-extensions@workspace:packages/lib-extensions"
   peerDependencies:
     "@openshift/dynamic-plugin-sdk": ^2.0.0
-    react: ^17.0.2
+    react: ^17 || ^18
     react-redux: ^7.2.2
     react-router: ^5.2.1
     redux: ^4.1.2
@@ -2867,7 +2867,7 @@ __metadata:
     "@patternfly/react-styles": ^4.52.16
     "@patternfly/react-table": ^4.71.16
     "@patternfly/react-virtualized-extension": ^4.53.2
-    react: ^17.0.2
+    react: ^17 || ^18
     react-redux: ^7.2.2
     react-router: ^5.2.1
     react-router-dom: ^6.3.0
@@ -2922,7 +2922,7 @@ __metadata:
     uuid: ^8.3.2
     yup: ^0.32.11
   peerDependencies:
-    react: ^17.0.2
+    react: ^17 || ^18
   languageName: node
   linkType: soft
 
@@ -2935,7 +2935,7 @@ __metadata:
     uuid: ^8.3.2
     yup: ^0.32.11
   peerDependencies:
-    react: ^17.0.2
+    react: ^17 || ^18
   languageName: node
   linkType: soft
 
@@ -2948,7 +2948,7 @@ __metadata:
     uuid: ^8.3.2
     yup: ^0.32.11
   peerDependencies:
-    react: ^17.0.2
+    react: ^17 || ^18
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
React `18.0.0` was published on 2022-03-29 and some projects might have already upgraded from React 17 to 18.

This PR adds technical compatibility with React 18 in terms of package peer dependencies.

- Plugin SDK packages will continue to be built with React 17
- Sample plugin and host app will continue to use React 17

Once available and stable, we will switch from PatternFly 4 to 5 (and using React 18) within the dynamic plugin SDK repo.