### PR TITLE
Prepare for next release of dist packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/react-dom": "^17.0.14",
     "@types/react-router": "^5.1.17",
     "@types/react-router-dom": "^5.3.3",
-    "@types/react-test-renderer": "^18.0.0",
+    "@types/react-test-renderer": "^17.0.2",
     "@types/react-virtualized": "^9.21.21",
     "@types/semver": "^7.3.10",
     "@types/uuid": "^8.3.4",

--- a/packages/lib-core/CHANGELOG.md
+++ b/packages/lib-core/CHANGELOG.md
@@ -1,12 +1,23 @@
 # Changelog for `@openshift/dynamic-plugin-sdk`
 
+## 3.0.0 - 2023-03-01
+
+> This release adds new mandatory field to plugin manifest: `baseURL`.
+> Use the `PluginLoader` option `postProcessManifest` to adapt existing manifests.
+
+- Allow plugins to pass custom properties via plugin manifest ([#204])
+- Add `sdkVersion` to `PluginStore` for better runtime diagnostics ([#200])
+- Provide direct access to raw plugin manifest data ([#207])
+- Remove `PluginStore` option `postProcessExtensions` ([#207])
+- Add technical compatibility with React 18 ([#208])
+
 ## 2.0.1 - 2023-01-27
 
 - Call `postProcessManifest` regardless of plugin manifest origin ([#190])
 
 ## 2.0.0 - 2023-01-23
 
-> This release adds new mandatory fields to the plugin manifest.
+> This release adds new mandatory fields to plugin manifest: `loadScripts`, `registrationMethod`.
 > Use the `PluginLoader` option `postProcessManifest` to adapt existing manifests.
 
 - Support loading plugins built with webpack library type other than `jsonp` ([#182])
@@ -24,3 +35,7 @@
 [#182]: https://github.com/openshift/dynamic-plugin-sdk/pull/182
 [#184]: https://github.com/openshift/dynamic-plugin-sdk/pull/184
 [#190]: https://github.com/openshift/dynamic-plugin-sdk/pull/190
+[#200]: https://github.com/openshift/dynamic-plugin-sdk/pull/200
+[#204]: https://github.com/openshift/dynamic-plugin-sdk/pull/204
+[#207]: https://github.com/openshift/dynamic-plugin-sdk/pull/207
+[#208]: https://github.com/openshift/dynamic-plugin-sdk/pull/208

--- a/packages/lib-core/package.json
+++ b/packages/lib-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Allows loading, managing and interpreting dynamic plugins",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/lib-extensions/package.json
+++ b/packages/lib-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-extensions",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Provides extension types for dynamic plugins",
   "license": "Apache-2.0",
   "repository": {
@@ -24,7 +24,7 @@
     "api-extractor": "yarn run -T api-extractor -c $INIT_CWD/api-extractor.json"
   },
   "peerDependencies": {
-    "@openshift/dynamic-plugin-sdk": "^2.0.0",
+    "@openshift/dynamic-plugin-sdk": "^3.0.0",
     "react": "^17 || ^18",
     "react-redux": "^7.2.2",
     "react-router": "^5.2.1",

--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-utils",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Provides React focused dynamic plugin SDK utilities",
   "license": "Apache-2.0",
   "repository": {
@@ -25,8 +25,8 @@
     "api-extractor": "yarn run -T api-extractor -c $INIT_CWD/api-extractor.json"
   },
   "peerDependencies": {
-    "@openshift/dynamic-plugin-sdk": "^2.0.0",
-    "@openshift/dynamic-plugin-sdk-extensions": "^1.1.0",
+    "@openshift/dynamic-plugin-sdk": "^3.0.0",
+    "@openshift/dynamic-plugin-sdk-extensions": "^1.2.0",
     "@patternfly/react-core": "^4.202.16",
     "@patternfly/react-icons": "^4.53.16",
     "@patternfly/react-styles": "^4.52.16",

--- a/packages/lib-webpack/CHANGELOG.md
+++ b/packages/lib-webpack/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for `@openshift/dynamic-plugin-sdk-webpack`
 
+## 3.0.0 - 2023-03-01
+
+- Add base URL for plugin assets to plugin manifest ([#206])
+- Make `DynamicRemotePlugin` options `pluginMetadata` and `extensions` mandatory ([#207])
+- Replace `DynamicRemotePlugin` option `moduleFederationLibraryType` with `moduleFederationSettings` ([#199])
+- Allow building plugins which do not provide any exposed modules ([#199])
+
 ## 2.0.0 - 2023-01-23
 
 - Support building plugins using webpack library type other than `jsonp` ([#182])
@@ -13,3 +20,6 @@
 
 [#182]: https://github.com/openshift/dynamic-plugin-sdk/pull/182
 [#184]: https://github.com/openshift/dynamic-plugin-sdk/pull/184
+[#199]: https://github.com/openshift/dynamic-plugin-sdk/pull/199
+[#206]: https://github.com/openshift/dynamic-plugin-sdk/pull/206
+[#207]: https://github.com/openshift/dynamic-plugin-sdk/pull/207

--- a/packages/lib-webpack/package.json
+++ b/packages/lib-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-webpack",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Allows building dynamic plugin assets with webpack",
   "license": "Apache-2.0",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2625,7 +2625,7 @@ __metadata:
     "@types/react-dom": ^17.0.14
     "@types/react-router": ^5.1.17
     "@types/react-router-dom": ^5.3.3
-    "@types/react-test-renderer": ^18.0.0
+    "@types/react-test-renderer": ^17.0.2
     "@types/react-virtualized": ^9.21.21
     "@types/semver": ^7.3.10
     "@types/uuid": ^8.3.4
@@ -2799,7 +2799,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openshift/dynamic-plugin-sdk-extensions@portal:../lib-extensions::locator=%40monorepo%2Fsample-app%40workspace%3Apackages%2Fsample-app"
   peerDependencies:
-    "@openshift/dynamic-plugin-sdk": ^2.0.0
+    "@openshift/dynamic-plugin-sdk": ^3.0.0
     react: ^17 || ^18
     react-redux: ^7.2.2
     react-router: ^5.2.1
@@ -2818,7 +2818,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openshift/dynamic-plugin-sdk-extensions@portal:../lib-extensions::locator=%40monorepo%2Fsample-plugin%40workspace%3Apackages%2Fsample-plugin"
   peerDependencies:
-    "@openshift/dynamic-plugin-sdk": ^2.0.0
+    "@openshift/dynamic-plugin-sdk": ^3.0.0
     react: ^17 || ^18
     react-redux: ^7.2.2
     react-router: ^5.2.1
@@ -2837,7 +2837,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openshift/dynamic-plugin-sdk-extensions@workspace:packages/lib-extensions"
   peerDependencies:
-    "@openshift/dynamic-plugin-sdk": ^2.0.0
+    "@openshift/dynamic-plugin-sdk": ^3.0.0
     react: ^17 || ^18
     react-redux: ^7.2.2
     react-router: ^5.2.1
@@ -2862,8 +2862,8 @@ __metadata:
     typesafe-actions: ^4.4.2
     uuid: ^8.3.2
   peerDependencies:
-    "@openshift/dynamic-plugin-sdk": ^2.0.0
-    "@openshift/dynamic-plugin-sdk-extensions": ^1.1.0
+    "@openshift/dynamic-plugin-sdk": ^3.0.0
+    "@openshift/dynamic-plugin-sdk-extensions": ^1.2.0
     "@patternfly/react-core": ^4.202.16
     "@patternfly/react-icons": ^4.53.16
     "@patternfly/react-styles": ^4.52.16
@@ -5149,12 +5149,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-test-renderer@npm:^18.0.0":
-  version: 18.0.0
-  resolution: "@types/react-test-renderer@npm:18.0.0"
+"@types/react-test-renderer@npm:^17.0.2":
+  version: 17.0.2
+  resolution: "@types/react-test-renderer@npm:17.0.2"
   dependencies:
-    "@types/react": "*"
-  checksum: 6afc938a1d7618d88ab8793e251f0bd5981bf3f08c1b600f74df3f8800b92589ea534dc6dcb7c8d683893fcc740bf8d7843a42bf2dae59785cfe88f004bd7b0b
+    "@types/react": ^17
+  checksum: 0be325798b6b38cc31fbb11f2f1e1a5578cc3b23eddf1ddd1ab58ccf50966e8f779383084d8bc3a7db3108ad815af8fbae5c0f54329a88d52200e01547d85c33
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Release preparation
- Update changelogs
- Bump package versions
  - lib-core :arrow_right: `3.0.0`
  - lib-extensions :arrow_right: `1.2.0` (due to updated peer deps)
  - lib-utils :arrow_right: `1.2.0` (due to updated peer deps)
  - lib-webpack :arrow_right: `3.0.0`

### Minor fixes
- Change `@types/react-test-renderer` dependency to match React version used
