### PR TITLE
RHCLOUD-24738: Fix bug in ValidateCompilationPlugin

### DIFF
--- a/packages/lib-webpack/src/webpack/PatchEntryCallbackPlugin.ts
+++ b/packages/lib-webpack/src/webpack/PatchEntryCallbackPlugin.ts
@@ -28,6 +28,7 @@ export class PatchEntryCallbackPlugin implements WebpackPluginInstance {
               } else {
                 const error = new WebpackError(`Missing call to ${this.callbackName}`);
                 error.file = fileName;
+                error.chunk = entryChunk;
                 compilation.errors.push(error);
               }
 

--- a/packages/lib-webpack/src/webpack/ValidateCompilationPlugin.ts
+++ b/packages/lib-webpack/src/webpack/ValidateCompilationPlugin.ts
@@ -5,24 +5,21 @@ export class ValidateCompilationPlugin implements WebpackPluginInstance {
   constructor(private readonly containerName: string, private readonly jsonpLibraryType: boolean) {}
 
   apply(compiler: Compiler) {
-    compiler.hooks.afterCompile.tap(ValidateCompilationPlugin.name, (compilation) => {
+    compiler.hooks.done.tap(ValidateCompilationPlugin.name, ({ compilation }) => {
       const { runtimeChunk } = findPluginChunks(this.containerName, compilation);
 
-      if (runtimeChunk && this.jsonpLibraryType) {
-        compilation.errors.push(
-          new WebpackError(
-            'Detected separate runtime chunk while using jsonp library type.\n' +
-              'This configuration is not allowed since it will cause issues with reloading plugins at runtime.\n' +
-              'Update your webpack configuration to avoid emitting a separate runtime chunk.',
-          ),
-        );
-      } else if (runtimeChunk) {
-        compilation.warnings.push(
-          new WebpackError(
-            'Detected separate runtime chunk while using non-jsonp library type.\n' +
-              'This configuration is not recommended since it may cause issues with reloading plugins at runtime.',
-          ),
-        );
+      if (runtimeChunk) {
+        const errorMessage = this.jsonpLibraryType
+          ? 'Detected separate runtime chunk while using jsonp library type.\n' +
+            'This configuration is not allowed since it will cause issues when reloading plugins at runtime.\n' +
+            'Please update your webpack configuration to avoid emitting a separate runtime chunk.'
+          : 'Detected separate runtime chunk while using non-jsonp library type.\n' +
+            'This configuration is not recommended since it may cause issues when reloading plugins at runtime.\n' +
+            'Consider updating your webpack configuration to avoid emitting a separate runtime chunk.';
+
+        const error = new WebpackError(errorMessage);
+        error.chunk = runtimeChunk;
+        (this.jsonpLibraryType ? compilation.errors : compilation.warnings).push(error);
       }
     });
   }


### PR DESCRIPTION
Fixes [RHCLOUD-24738](https://issues.redhat.com/browse/RHCLOUD-24738)

Some webpack plugins like [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) use `compilation.createChildCompiler` API to run a "child" compilation inside the actual "root" compilation.

> This function allows you to run another instance of webpack inside of webpack however as a child with different settings and configurations (if desired) applied. It copies all hooks, plugins from parent (or top level compiler) and creates a child Compilation

Since our `ValidateCompilationPlugin` uses `afterCompile` hook _which is automatically copied to all child compilers_, using e.g. `html-webpack-plugin` (*) caused this hook to be executed within `html-webpack-plugin`'s child compilation which doesn't include any of the expected root compilation's actual chunks.

(*) see [here](https://github.com/jantimon/html-webpack-plugin/blob/v5.5.0/lib/child-compiler.js#L104) for details

The fix is to use an appropriate webpack compiler hook that isn't automatically copied to all child compilers.

The list of compiler hooks that are _not_ automatically copied to all child compilers is in `webpack/lib/Compiler.js`
```ts
for (const name in this.hooks) {
  if (
    ![
      "make",
      "compile",
      "emit",
      "afterEmit",
      "invalid",
      "done",
      "thisCompilation"
    ].includes(name)
  ) {
    if (childCompiler.hooks[name]) {
      childCompiler.hooks[name].taps = this.hooks[name].taps.slice();
    }
  }
}
```
