### PR TITLE
Publish lib-utils version 2.0.0

### DIFF
--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-utils",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Provides React focused dynamic plugin SDK utilities",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Publishes breaking workspace changes including: https://github.com/openshift/dynamic-plugin-sdk/pull/202

We will need to update the import in hac-core to pull in this new major range: https://github.com/openshift/hac-core/blob/main/frontend/package.json#L31

And also update the hac-dev plugin to use the new hook name (`setActiveWorkspaceLocalStorage`): https://github.com/openshift/hac-dev/search?q=setActiveWorkspace


```bash
npm notice 
npm notice 📦  @openshift/dynamic-plugin-sdk-utils@2.0.0
npm notice === Tarball Contents === 
npm notice 96B     README.md               
npm notice 253B    dist/build-metadata.json
npm notice 1.3kB   dist/index.css          
npm notice 37.4kB  dist/index.d.ts         
npm notice 113.1kB dist/index.js           
npm notice 1.6kB   package.json            
npm notice === Tarball Details === 
npm notice name:          @openshift/dynamic-plugin-sdk-utils          
npm notice version:       2.0.0                                        
npm notice filename:      @openshift/dynamic-plugin-sdk-utils-2.0.0.tgz
npm notice package size:  36.8 kB                                      
npm notice unpacked size: 153.7 kB                                     
npm notice shasum:        a019398d5cdd3bcb5f1530fbb354652d6d92bef7     
npm notice integrity:     sha512-eBTxsCxx7ysSz[...]oe8ABdB6HMQNg==     
npm notice total files:   6                                            
npm notice 
npm notice Publishing to https://registry.npmjs.org/
This operation requires a one-time password.
Enter OTP: 🙈
+ @openshift/dynamic-plugin-sdk-utils@2.0.0
```