### PR TITLE
[RHCLOUD-25061] Handle cluster scoped resources and multiple workspaces

### DIFF
--- a/packages/lib-utils/src/utils/WorkspaceContext.ts
+++ b/packages/lib-utils/src/utils/WorkspaceContext.ts
@@ -17,7 +17,7 @@ const WorkspaceContext = createContext<ReturnType<typeof workspaceState>>({
   subscribe: () => '',
   unsubscribe: () => undefined,
   getState: () => ({
-    subscribtions: {},
+    subscriptions: {},
     activeWorkspace: null,
   }),
 });

--- a/packages/lib-utils/src/utils/workspaceState.ts
+++ b/packages/lib-utils/src/utils/workspaceState.ts
@@ -26,7 +26,6 @@ export const workspaceState = () => {
   // add subscriber (hook) to registry
   function subscribe(event: UpdateEvents, onUpdate: () => void) {
     const id = uuidv4();
-    // const id = `${Date.now()}${Math.random()}`;
     subscriptions[event][id] = onUpdate;
     // trigger initial update to get the initial data
     onUpdate();


### PR DESCRIPTION
* Handles a non-namespaced model as a cluster-level resource and will not prepend the active workspace
* TODO: multiple workspace support