### PR TITLE
Generate plugin manifest after asset hashing phase.

### DIFF
--- a/packages/lib-webpack/src/webpack/PatchEntryCallbackPlugin.ts
+++ b/packages/lib-webpack/src/webpack/PatchEntryCallbackPlugin.ts
@@ -17,7 +17,7 @@ export class PatchEntryCallbackPlugin implements WebpackPluginInstance {
       compilation.hooks.processAssets.tap(
         {
           name: PatchEntryCallbackPlugin.name,
-          stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+          stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
         },
         () => {
           const { entryChunk } = findPluginChunks(containerName, compilation);

--- a/packages/sample-plugin/webpack.config.ts
+++ b/packages/sample-plugin/webpack.config.ts
@@ -38,7 +38,7 @@ const plugins: WebpackPluginInstance[] = [
     pluginMetadata,
     extensions,
     sharedModules: pluginSharedModules,
-    entryScriptFilename: isProd ? 'plugin-entry.[fullhash].min.js' : 'plugin-entry.js',
+    entryScriptFilename: isProd ? 'plugin-entry.[contenthash].min.js' : 'plugin-entry.js',
   }),
 ];
 


### PR DESCRIPTION
The manifest has to be generated after webpack hashes the files.
Otherwise, the plugin manifest may contain non final hashes and therefore pointing to non existing assets.
For example: foo.[contenthash].js
 the hash is changed during the build
 the final hash is decided at the compilation.afterHash
 if we generate the manifest before the hash phase is finished and assets are ready to be emitted, we can get temporary build hahs instead of final asset hash
 the hashing can be changed like this:
   1. foo.[contenthash].js // initial mask
   2. foo.1234.js // 1234 is build hash
   3. foo.abc.js // abc is the compiled asset content hash
The emit hook is a great candidate to search for asset hash as it is run after all assets are sealed and right before they are emitted to the filesystem. 