### PR TITLE
Improve error handling

### DIFF
--- a/packages/lib-core/src/index.ts
+++ b/packages/lib-core/src/index.ts
@@ -24,7 +24,7 @@ export {
 
 // Core components
 export { PluginLoaderOptions } from './runtime/PluginLoader';
-export { PluginStore, PluginStoreOptions } from './runtime/PluginStore';
+export { PluginStore, PluginStoreOptions, PluginErrorDetails } from './runtime/PluginStore';
 export {
   PluginStoreProvider,
   PluginStoreProviderProps,

--- a/packages/lib-core/src/types/store.ts
+++ b/packages/lib-core/src/types/store.ts
@@ -144,4 +144,21 @@ export type PluginStoreInterface = {
     pluginName: string,
     moduleName: string,
   ) => Promise<TModule>;
+
+  /**
+   * Notify the `PluginStore` that an error has occurred while processing the given plugin
+   * or its extensions.
+   *
+   * If a plugin with the given name is currently loaded, this method will pass provided
+   * error details to the custom plugin error handler registered with the `PluginStore`.
+   *
+   * The `reportedBy` argument indicates which code has reported the error. For example,
+   * the `useResolvedExtensions` hook sets this value to `"useResolvedExtensions"`.
+   */
+  reportPluginError: (
+    pluginName: string,
+    reportedBy: string,
+    errorMessage: string,
+    errorCause?: unknown,
+  ) => void;
 };

--- a/reports/lib-core.api.md
+++ b/reports/lib-core.api.md
@@ -137,6 +137,17 @@ export type PluginEntryModule = {
 };
 
 // @public (undocumented)
+export type PluginErrorDetails = {
+    message: string;
+    cause?: unknown;
+} & ({
+    loadError: true;
+} | {
+    loadError: false;
+    reportedBy: string;
+});
+
+// @public (undocumented)
 export enum PluginEventType {
     ExtensionsChanged = "ExtensionsChanged",
     FeatureFlagsChanged = "FeatureFlagsChanged",
@@ -201,6 +212,8 @@ export class PluginStore implements PluginStoreInterface {
     // (undocumented)
     loadPlugin(manifest: PluginManifest | string, forceReload?: boolean): Promise<void>;
     // (undocumented)
+    reportPluginError(pluginName: string, reportedBy: string, errorMessage: string, errorCause?: unknown): void;
+    // (undocumented)
     readonly sdkVersion: string;
     // (undocumented)
     setFeatureFlags(newFlags: FeatureFlags): void;
@@ -220,12 +233,14 @@ export type PluginStoreInterface = {
     enablePlugins: (pluginNames: string[]) => void;
     disablePlugins: (pluginNames: string[], disableReason?: string) => void;
     getExposedModule: <TModule extends AnyObject>(pluginName: string, moduleName: string) => Promise<TModule>;
+    reportPluginError: (pluginName: string, reportedBy: string, errorMessage: string, errorCause?: unknown) => void;
 };
 
 // @public (undocumented)
 export type PluginStoreOptions = Partial<{
     loaderOptions: PluginLoaderOptions;
     autoEnableLoadedPlugins: boolean;
+    pluginErrorHandler: (manifest: PluginManifest, errorDetails: PluginErrorDetails) => void;
 }>;
 
 // @public


### PR DESCRIPTION
This PR allows the host application to handle both load-time and runtime errors related to plugins.

- new `PluginStore` option `pluginErrorHandler`
  - if `errorDetails.loadError` is `true`, the error has occurred while loading the given plugin
  - if `errorDetails.loadError` is `false`, the error was reported for an already loaded plugin (see below)
```ts
pluginErrorHandler: (manifest: PluginManifest, errorDetails: PluginErrorDetails) => void;
```

- new `PluginStore` interface method `reportPluginError`
  - if the given plugin is currently loaded, pass provided error details to `pluginErrorHandler`
  - if the given plugin is not currently loaded, issue a console warning and do nothing
```ts
reportPluginError: (
  pluginName: string,
  reportedBy: string,
  errorMessage: string,
  errorCause?: unknown,
) => void;
```

- `useResolvedExtensions` hook reports code reference resolution errors via `reportPluginError` API

- `useResolvedExtensions` hook _**does not**_ disable problematic plugins by default anymore
  - aligns with openshift/console#12347
  - if necessary, problematic plugins can be disabled via the application provided `pluginErrorHandler`
```ts
const pluginStore = new PluginStore({
  // ... other options ...
  pluginErrorHandler: (manifest, errorDetails) => {
    if (!errorDetails.loadError && errorDetails.reportedBy === 'useResolvedExtensions') {
      pluginStore.disablePlugins([manifest.name], 'Errors while resolving code references');
    }
  },
});
```