### PR TITLE
Publish version 3.0.0 of the lib-utils package

### DIFF
--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-utils",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Provides React focused dynamic plugin SDK utilities",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This includes a few bug fixes that are not backwards compatible with version 2.1.0 (hence the major bump)

https://www.npmjs.com/package/@openshift/dynamic-plugin-sdk-utils?activeTab=versions

```
npm notice 📦  @openshift/dynamic-plugin-sdk-utils@3.0.0
npm notice === Tarball Contents ===
npm notice 96B     README.md
npm notice 255B    dist/build-metadata.json
npm notice 123.6kB dist/index.cjs.js
npm notice 1.3kB   dist/index.css
npm notice 38.6kB  dist/index.d.ts
npm notice 115.2kB dist/index.esm.js
npm notice 1.6kB   package.json
npm notice === Tarball Details ===
npm notice name:          @openshift/dynamic-plugin-sdk-utils
npm notice version:       3.0.0
npm notice filename:      @openshift/dynamic-plugin-sdk-utils-3.0.0.tgz
npm notice package size:  64.8 kB
npm notice unpacked size: 280.7 kB
npm notice shasum:        42270dbdf3bf015c3d10a23de357207d31f3626c
npm notice integrity:     sha512-qOyeDIcUEvRBY[...]FM2TOF1zXjkCg==
npm notice total files:   7
npm notice
npm notice Publishing to https://registry.npmjs.org/
+ @openshift/dynamic-plugin-sdk-utils@3.0.0
```