### PR TITLE
Publish lib-utils 4.0.0 (PF5 support)

### DIFF
--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-utils",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Provides React focused dynamic plugin SDK utilities",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
npm notice 📦  @openshift/dynamic-plugin-sdk-utils@4.0.0 npm notice === Tarball Contents ===
npm notice 96B     README.md
npm notice 250B    dist/build-metadata.json
npm notice 124.1kB dist/index.cjs.js
npm notice 1.3kB   dist/index.css
npm notice 38.6kB  dist/index.d.ts
npm notice 115.7kB dist/index.esm.js
npm notice 1.6kB   package.json

npm notice === Tarball Details ===
npm notice name:          @openshift/dynamic-plugin-sdk-utils
npm notice version:       4.0.0
npm notice filename:      openshift-dynamic-plugin-sdk-utils-4.0.0.tgz
npm notice package size:  64.9 kB
npm notice unpacked size: 281.6 kB
npm notice shasum:        fce05bb2a451f174039cd983a9c7323372e6b30c
npm notice integrity:     sha512-BiUUHgCjbcwXy[...]dCVqZ0dV6M26Q==
npm notice total files:   7