### PR TITLE
Validate dependency values in DynamicRemotePlugin

### DIFF
--- a/packages/lib-core/src/runtime/PluginLoader.ts
+++ b/packages/lib-core/src/runtime/PluginLoader.ts
@@ -171,7 +171,7 @@ export class PluginLoader implements PluginLoaderInterface {
     const responseText = await response.text();
     const manifest = this.options.transformPluginManifest(JSON.parse(responseText));
 
-    pluginManifestSchema.strict(true).validateSync(manifest, { abortEarly: false });
+    pluginManifestSchema.validateSync(manifest, { strict: true, abortEarly: false });
 
     return manifest;
   }

--- a/packages/lib-webpack/package.json
+++ b/packages/lib-webpack/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
+    "semver": "^7.3.7",
     "yup": "^0.32.11"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,6 +2881,7 @@ __metadata:
   resolution: "@openshift/dynamic-plugin-sdk-webpack@portal:../lib-webpack::locator=%40monorepo%2Fsample-app%40workspace%3Apackages%2Fsample-app"
   dependencies:
     lodash: ^4.17.21
+    semver: ^7.3.7
     yup: ^0.32.11
   peerDependencies:
     webpack: ^5.75.0
@@ -2892,6 +2893,7 @@ __metadata:
   resolution: "@openshift/dynamic-plugin-sdk-webpack@portal:../lib-webpack::locator=%40monorepo%2Fsample-plugin%40workspace%3Apackages%2Fsample-plugin"
   dependencies:
     lodash: ^4.17.21
+    semver: ^7.3.7
     yup: ^0.32.11
   peerDependencies:
     webpack: ^5.75.0
@@ -2903,6 +2905,7 @@ __metadata:
   resolution: "@openshift/dynamic-plugin-sdk-webpack@workspace:packages/lib-webpack"
   dependencies:
     lodash: ^4.17.21
+    semver: ^7.3.7
     yup: ^0.32.11
   peerDependencies:
     webpack: ^5.75.0


### PR DESCRIPTION
- add `semver` dependency to lib-webpack
- use `semver.validRange` to validate values of `pluginMetadata.dependencies` object