### PR TITLE
Disallow empty string dependency values in DynamicRemotePlugin

### DIFF
--- a/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
+++ b/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
@@ -165,7 +165,8 @@ export class DynamicRemotePlugin implements WebpackPluginInstance {
     const invalidDepNames = Object.entries(
       this.adaptedOptions.pluginMetadata.dependencies ?? {},
     ).reduce<string[]>(
-      (acc, [depName, versionRange]) => (semver.validRange(versionRange) ? acc : [...acc, depName]),
+      (acc, [depName, versionRange]) =>
+        versionRange && semver.validRange(versionRange) ? acc : [...acc, depName],
       [],
     );
 


### PR DESCRIPTION
The `semver` library coerces an empty string to `*` version range, e.g.
```ts
semver.validRange('')
// => '*'
```
This PR updates `DynamicRemotePlugin` to disallow empty strings when validating values of `pluginMetadata.dependencies` object.