### PR TITLE
Improve core logic and useResolvedExtensions hook

### DIFF
--- a/packages/common/src/errors/ErrorWithCause.ts
+++ b/packages/common/src/errors/ErrorWithCause.ts
@@ -6,7 +6,7 @@ import { CustomError } from './CustomError';
  * This shouldn't be needed once https://github.com/tc39/proposal-error-cause receives widespread support.
  */
 export class ErrorWithCause extends CustomError {
-  constructor(message: string, readonly cause?: unknown) {
+  constructor(message: string, readonly cause: unknown) {
     super(message);
   }
 }

--- a/packages/lib-core/src/index.ts
+++ b/packages/lib-core/src/index.ts
@@ -36,6 +36,7 @@ export { useExtensions } from './runtime/useExtensions';
 export {
   useResolvedExtensions,
   UseResolvedExtensionsResult,
+  UseResolvedExtensionsOptions,
 } from './runtime/useResolvedExtensions';
 export { usePluginInfo } from './runtime/usePluginInfo';
 export { useFeatureFlag, UseFeatureFlagResult } from './runtime/useFeatureFlag';

--- a/packages/lib-core/src/runtime/PluginStore.ts
+++ b/packages/lib-core/src/runtime/PluginStore.ts
@@ -227,7 +227,7 @@ export class PluginStore implements PluginStoreInterface {
         consoleLogger.warn(
           `Attempt to ${
             enabled ? 'enable' : 'disable'
-          } plugin ${pluginName} which is not loaded yet`,
+          } plugin ${pluginName} which is not currently loaded`,
         );
         return;
       }
@@ -346,7 +346,7 @@ export class PluginStore implements PluginStoreInterface {
   async getExposedModule<TModule extends AnyObject>(pluginName: string, moduleName: string) {
     if (!this.loadedPlugins.has(pluginName)) {
       throw new Error(
-        `Attempt to get module '${moduleName}' of plugin ${pluginName} which is not loaded yet`,
+        `Attempt to get module '${moduleName}' of plugin ${pluginName} which is not currently loaded`,
       );
     }
 

--- a/packages/lib-core/src/runtime/coderefs.ts
+++ b/packages/lib-core/src/runtime/coderefs.ts
@@ -1,5 +1,5 @@
 import type { AnyObject } from '@monorepo/common';
-import { CustomError, ErrorWithCause, visitDeep } from '@monorepo/common';
+import { ErrorWithCause, visitDeep } from '@monorepo/common';
 import { cloneDeep, has, identity, isEqual, isPlainObject } from 'lodash';
 import type {
   EncodedCodeRef,
@@ -9,16 +9,6 @@ import type {
   ResolvedExtension,
 } from '../types/extension';
 import type { PluginEntryModule } from '../types/runtime';
-
-class ExtensionCodeRefsResolutionError extends CustomError {
-  constructor(readonly extension: LoadedExtension, readonly causes: unknown[]) {
-    super();
-  }
-}
-
-export const isExtensionCodeRefsResolutionError = (
-  e: unknown,
-): e is ExtensionCodeRefsResolutionError => e instanceof ExtensionCodeRefsResolutionError;
 
 /**
  * Indicates that the given function is a {@link CodeRef} function.
@@ -126,18 +116,22 @@ export const decodeCodeRefs = (extension: LoadedExtension, entryModule: PluginEn
 };
 
 /**
- * In the extension's `properties` object, replace all {@link CodeRef} functions
- * with the corresponding values by resolving the associated Promises.
+ * In the extension's `properties` object, replace all {@link CodeRef} functions with
+ * their corresponding values by resolving the associated Promises.
  *
- * This is an asynchronous operation that completes when all of the associated
- * Promises are either resolved or rejected. If there were no resolution errors,
- * the resulting Promise resolves with the updated extension.
+ * This is an asynchronous operation that completes when all of the associated Promises
+ * are either resolved or rejected. Each code reference resolution error will cause the
+ * associated property value to be set to `undefined`.
  *
- * The updated extension is a new object; its `properties` are cloned in order
- * to preserve the original structure of decoded extensions.
+ * The resulting Promise resolves with a new extension instance; its `properties` object
+ * is cloned in order to preserve the original extension.
+ *
+ * The resulting Promise never rejects. Use the `onResolutionErrors` callback to handle
+ * any code reference resolution errors.
  */
 export const resolveCodeRefValues = async <TExtension extends Extension>(
   extension: LoadedExtension<TExtension>,
+  onResolutionErrors: (errors: unknown[]) => void,
 ) => {
   const clonedProperties = cloneDeep(extension.properties);
   const resolutions: Promise<void>[] = [];
@@ -162,7 +156,7 @@ export const resolveCodeRefValues = async <TExtension extends Extension>(
   await Promise.allSettled(resolutions);
 
   if (resolutionErrors.length > 0) {
-    throw new ExtensionCodeRefsResolutionError(extension, resolutionErrors);
+    onResolutionErrors(resolutionErrors);
   }
 
   return {

--- a/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
+++ b/packages/lib-webpack/src/webpack/DynamicRemotePlugin.ts
@@ -109,7 +109,8 @@ export type DynamicRemotePluginOptions = {
   /**
    * Customize the filename of the generated plugin entry script.
    *
-   * We recommend using the `[fullhash]` placeholder in production builds.
+   * We recommend using `[contenthash]` or `[fullhash]` placeholder in production builds,
+   * e.g. `plugin-entry.[contenthash].min.js`.
    *
    * Default value: `plugin-entry.js`.
    *

--- a/packages/lib-webpack/src/webpack/GenerateManifestPlugin.ts
+++ b/packages/lib-webpack/src/webpack/GenerateManifestPlugin.ts
@@ -25,24 +25,22 @@ export class GenerateManifestPlugin implements WebpackPluginInstance {
       );
     }
 
-    /**
-     * The manifest has to be generated within the emit hook after the webpack hashes the assets.
-     */
     compiler.hooks.thisCompilation.tap(GenerateManifestPlugin.name, (compilation) => {
       compilation.hooks.processAssets.tap(
         {
           name: GenerateManifestPlugin.name,
           // Using one of the later asset processing stages to ensure all assets
           // are already added to the compilation by other webpack plugins
-          stage: Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE
+          stage: Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE,
         },
         () => {
           const { entryChunk, runtimeChunk } = findPluginChunks(containerName, compilation);
           const pluginChunks = runtimeChunk ? [runtimeChunk, entryChunk] : [entryChunk];
 
-          const loadScripts = pluginChunks.reduce<
-            string[]
-          >((acc, chunk) => [...acc, ...chunk.files], []);
+          const loadScripts = pluginChunks.reduce<string[]>(
+            (acc, chunk) => [...acc, ...chunk.files],
+            [],
+          );
 
           const manifest = transformManifest({
             ...manifestData,
@@ -56,7 +54,7 @@ export class GenerateManifestPlugin implements WebpackPluginInstance {
             new sources.RawSource(Buffer.from(JSON.stringify(manifest, null, 2))),
           );
 
-          const warnings = [];
+          const warnings: string[] = [];
 
           if (manifest.extensions.length === 0) {
             warnings.push('Plugin has no extensions');
@@ -71,7 +69,7 @@ export class GenerateManifestPlugin implements WebpackPluginInstance {
             error.file = manifestFilename;
             compilation.warnings.push(error);
           });
-        }
+        },
       );
     });
   }

--- a/reports/lib-core.api.md
+++ b/reports/lib-core.api.md
@@ -302,7 +302,12 @@ export const usePluginInfo: () => PluginInfoEntry[];
 export const usePluginStore: () => PluginStoreInterface;
 
 // @public
-export const useResolvedExtensions: <TExtension extends Extension<string, AnyObject>>(predicate?: ExtensionPredicate<TExtension> | undefined) => UseResolvedExtensionsResult<TExtension>;
+export const useResolvedExtensions: <TExtension extends Extension<string, AnyObject>>(predicate?: ExtensionPredicate<TExtension> | undefined, options?: UseResolvedExtensionsOptions) => UseResolvedExtensionsResult<TExtension>;
+
+// @public (undocumented)
+export type UseResolvedExtensionsOptions = Partial<{
+    includeExtensionsWithResolutionErrors: boolean;
+}>;
 
 // @public (undocumented)
 export type UseResolvedExtensionsResult<TExtension extends Extension> = [


### PR DESCRIPTION
Notable changes
- update `resolveCodeRefValues` function to never reject and use `onResolutionErrors` callback instead
- add options to `useResolvedExtensions` hook for better control over code reference resolution errors
- remove "disable associated plugins on code reference resolution errors" logic in `useResolvedExtensions` hook
