### PR TITLE
Add python to installed system packages in CI buildroot image

### DIFF
--- a/docker/Dockerfile.ci-operator-buildroot
+++ b/docker/Dockerfile.ci-operator-buildroot
@@ -12,7 +12,7 @@ ENV NO_COLOR=1
 # Note that ci-operator requires git to be installed on the system.
 # https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image
 RUN dnf update -y && \
-    dnf install -y git jq openssl procps-ng && \
+    dnf install -y git python jq openssl procps-ng && \
     git config --system --add safe.directory '*' && \
     git config --system advice.detachedHead false
 


### PR DESCRIPTION
This should fix CI jobs failing due to [nvm](https://github.com/nvm-sh/nvm) unable to configure installed Node.js binary.
```
$>./configure --prefix=/go/.nvm/versions/node/v18.18.0 <
./configure: line 8: exec: python: not found
nvm: install v18.18.0 failed!
```