### PR TITLE
Prepare to publish new package versions

### DIFF
--- a/packages/lib-core/CHANGELOG.md
+++ b/packages/lib-core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog for `@openshift/dynamic-plugin-sdk`
 
+## 5.0.0 - 2023-11-03
+
+> This release adds the ability to provide your own plugin loader implementation when creating
+> the `PluginStore`. Note that the `useResolvedExtensions` hook does not automatically disable
+> plugins whose extensions have code reference resolution errors.
+
+- Rename `postProcessManifest` loader option to `transformPluginManifest` ([#236])
+- Support passing custom plugin loader implementation to `PluginStore` ([#232])
+- Add `TestPluginStore` intended for React component testing purposes ([#232])
+- Add options to `useResolvedExtensions` hook to customize its default behavior ([#241])
+
 ## 4.0.0 - 2023-04-13
 
 > This release removes the `PluginLoader` export. Pass the former `PluginLoader`
@@ -55,3 +66,6 @@
 [#208]: https://github.com/openshift/dynamic-plugin-sdk/pull/208
 [#212]: https://github.com/openshift/dynamic-plugin-sdk/pull/212
 [#215]: https://github.com/openshift/dynamic-plugin-sdk/pull/215
+[#232]: https://github.com/openshift/dynamic-plugin-sdk/pull/232
+[#236]: https://github.com/openshift/dynamic-plugin-sdk/pull/236
+[#241]: https://github.com/openshift/dynamic-plugin-sdk/pull/241

--- a/packages/lib-core/package.json
+++ b/packages/lib-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Allows loading, managing and interpreting dynamic plugins",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/lib-extensions/package.json
+++ b/packages/lib-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-extensions",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Provides extension types for dynamic plugins",
   "license": "Apache-2.0",
   "repository": {
@@ -26,7 +26,7 @@
     "api-extractor": "yarn run -T api-extractor -c $INIT_CWD/api-extractor.json"
   },
   "peerDependencies": {
-    "@openshift/dynamic-plugin-sdk": "^4.0.0",
+    "@openshift/dynamic-plugin-sdk": "^4 || ^5",
     "react": "^17 || ^18",
     "react-redux": "^7.2.2",
     "react-router": "^5.2.1",

--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-utils",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Provides React focused dynamic plugin SDK utilities",
   "license": "Apache-2.0",
   "repository": {
@@ -27,8 +27,8 @@
     "api-extractor": "yarn run -T api-extractor -c $INIT_CWD/api-extractor.json"
   },
   "peerDependencies": {
-    "@openshift/dynamic-plugin-sdk": "^4.0.0",
-    "@openshift/dynamic-plugin-sdk-extensions": "^1.3.0",
+    "@openshift/dynamic-plugin-sdk": "^4 || ^5",
+    "@openshift/dynamic-plugin-sdk-extensions": "^1.4.0",
     "@patternfly/react-core": "^5.1.0",
     "@patternfly/react-icons": "^5.1.0",
     "@patternfly/react-styles": "^5.1.0",

--- a/packages/lib-webpack/CHANGELOG.md
+++ b/packages/lib-webpack/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog for `@openshift/dynamic-plugin-sdk-webpack`
 
+## 4.0.0 - 2023-11-03
+
+> Any custom properties in the plugin manifest should be set via the `customProperties` object.
+> Use the `DynamicRemotePlugin` option `transformPluginManifest` to add such custom properties
+> to the generated plugin manifest.
+
+- Add `transformPluginManifest` option to `DynamicRemotePlugin` ([#236])
+- Rename `sharedScope` to `sharedScopeName` in `moduleFederationSettings` ([#236])
+- Validate values of plugin metadata `dependencies` object as semver ranges ([#239])
+- Disallow empty strings as values of plugin metadata `dependencies` object ([#240])
+- Fix bug in `DynamicRemotePlugin` where `buildHash` in plugin manifest is not generated properly ([#227])
+
 ## 3.0.1 - 2023-04-13
 
 - Fix bug in `DynamicRemotePlugin` that occurs with webpack `createChildCompiler` usage ([#213])
@@ -30,3 +42,7 @@
 [#207]: https://github.com/openshift/dynamic-plugin-sdk/pull/207
 [#213]: https://github.com/openshift/dynamic-plugin-sdk/pull/213
 [#215]: https://github.com/openshift/dynamic-plugin-sdk/pull/215
+[#227]: https://github.com/openshift/dynamic-plugin-sdk/pull/227
+[#236]: https://github.com/openshift/dynamic-plugin-sdk/pull/236
+[#239]: https://github.com/openshift/dynamic-plugin-sdk/pull/239
+[#240]: https://github.com/openshift/dynamic-plugin-sdk/pull/240

--- a/packages/lib-webpack/package.json
+++ b/packages/lib-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-webpack",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Allows building dynamic plugin assets with webpack",
   "license": "Apache-2.0",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2796,7 +2796,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openshift/dynamic-plugin-sdk-extensions@portal:../lib-extensions::locator=%40monorepo%2Fsample-app%40workspace%3Apackages%2Fsample-app"
   peerDependencies:
-    "@openshift/dynamic-plugin-sdk": ^4.0.0
+    "@openshift/dynamic-plugin-sdk": ^4 || ^5
     react: ^17 || ^18
     react-redux: ^7.2.2
     react-router: ^5.2.1
@@ -2815,7 +2815,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openshift/dynamic-plugin-sdk-extensions@portal:../lib-extensions::locator=%40monorepo%2Fsample-plugin%40workspace%3Apackages%2Fsample-plugin"
   peerDependencies:
-    "@openshift/dynamic-plugin-sdk": ^4.0.0
+    "@openshift/dynamic-plugin-sdk": ^4 || ^5
     react: ^17 || ^18
     react-redux: ^7.2.2
     react-router: ^5.2.1
@@ -2834,7 +2834,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openshift/dynamic-plugin-sdk-extensions@workspace:packages/lib-extensions"
   peerDependencies:
-    "@openshift/dynamic-plugin-sdk": ^4.0.0
+    "@openshift/dynamic-plugin-sdk": ^4 || ^5
     react: ^17 || ^18
     react-redux: ^7.2.2
     react-router: ^5.2.1
@@ -2859,8 +2859,8 @@ __metadata:
     typesafe-actions: ^4.4.2
     uuid: ^8.3.2
   peerDependencies:
-    "@openshift/dynamic-plugin-sdk": ^4.0.0
-    "@openshift/dynamic-plugin-sdk-extensions": ^1.3.0
+    "@openshift/dynamic-plugin-sdk": ^4 || ^5
+    "@openshift/dynamic-plugin-sdk-extensions": ^1.4.0
     "@patternfly/react-core": ^5.1.0
     "@patternfly/react-icons": ^5.1.0
     "@patternfly/react-styles": ^5.1.0


### PR DESCRIPTION
- `@openshift/dynamic-plugin-sdk` 4.0.0 :arrow_right: 5.0.0 (see changelog for details)
- `@openshift/dynamic-plugin-sdk-extensions` 1.3.0 :arrow_right: 1.4.0 (due to change in `peerDependencies`)
- `@openshift/dynamic-plugin-sdk-utils` 4.0.1 :arrow_right: 4.1.0 (due to change in `peerDependencies`)
- `@openshift/dynamic-plugin-sdk-webpack` 3.0.1 :arrow_right: 4.0.0 (see changelog for details)