### PR TITLE
Use [fullhash] instead of [contenthash] in entryScriptFilename

### DIFF
--- a/packages/sample-plugin/webpack.config.ts
+++ b/packages/sample-plugin/webpack.config.ts
@@ -38,7 +38,7 @@ const plugins: WebpackPluginInstance[] = [
     pluginMetadata,
     extensions,
     sharedModules: pluginSharedModules,
-    entryScriptFilename: isProd ? 'plugin-entry.[contenthash].min.js' : 'plugin-entry.js',
+    entryScriptFilename: isProd ? 'plugin-entry.[fullhash].min.js' : 'plugin-entry.js',
   }),
 ];
 


### PR DESCRIPTION
Using `[contenthash]` causes a bug where `loadScripts` in plugin manifest does not refer to the correct script filename.

This bug will be fixed in a follow-up PR.