### PR TITLE
Fix asset hash related bug in GenerateManifestPlugin

### DIFF
--- a/packages/lib-webpack/src/webpack/GenerateManifestPlugin.ts
+++ b/packages/lib-webpack/src/webpack/GenerateManifestPlugin.ts
@@ -30,8 +30,8 @@ export class GenerateManifestPlugin implements WebpackPluginInstance {
         {
           name: GenerateManifestPlugin.name,
           // Using one of the later asset processing stages to ensure all assets
-          // are already added to the compilation by other webpack plugins
-          stage: Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE,
+          // are already added and optimized within the given webpack compilation
+          stage: Compilation.PROCESS_ASSETS_STAGE_ANALYSE,
         },
         () => {
           const { entryChunk, runtimeChunk } = findPluginChunks(containerName, compilation);
@@ -49,9 +49,15 @@ export class GenerateManifestPlugin implements WebpackPluginInstance {
             buildHash: compilation.fullHash,
           });
 
+          const manifestContent = JSON.stringify(
+            manifest,
+            null,
+            compiler.options.mode === 'production' ? undefined : 2,
+          );
+
           compilation.emitAsset(
             manifestFilename,
-            new sources.RawSource(Buffer.from(JSON.stringify(manifest, null, 2))),
+            new sources.RawSource(Buffer.from(manifestContent)),
           );
 
           const warnings: string[] = [];

--- a/packages/sample-plugin/webpack.config.ts
+++ b/packages/sample-plugin/webpack.config.ts
@@ -38,7 +38,7 @@ const plugins: WebpackPluginInstance[] = [
     pluginMetadata,
     extensions,
     sharedModules: pluginSharedModules,
-    entryScriptFilename: isProd ? 'plugin-entry.[fullhash].min.js' : 'plugin-entry.js',
+    entryScriptFilename: isProd ? 'plugin-entry.[contenthash].min.js' : 'plugin-entry.js',
   }),
 ];
 


### PR DESCRIPTION
This PR fixes a bug that occurs when using `[contenthash]` placeholder within the generated entry script filename.

webpack compilation hook [`processAssets`](https://webpack.js.org/api/compilation-hooks/#processassets) stage `SUMMARIZE` runs before asset hash optimizations, therefore we need to use a later stage like `ANALYSE`.

Also, when running webpack in production mode, the generated plugin manifest JSON is no longer pretty formatted.