### PR TITLE
Always transform plugin manifest before loading the associated plugin

### DIFF
--- a/packages/lib-core/src/runtime/PluginLoader.ts
+++ b/packages/lib-core/src/runtime/PluginLoader.ts
@@ -115,7 +115,7 @@ export type PluginLoaderOptions = Partial<{
   sharedScope: AnyObject;
 
   /**
-   * Transform the plugin manifest.
+   * Transform the plugin manifest before loading the associated plugin.
    *
    * By default, no transformation is performed on the manifest.
    */
@@ -168,12 +168,15 @@ export class PluginLoader implements PluginLoaderInterface {
 
   async loadPluginManifest(manifestURL: string) {
     const response = await this.options.fetchImpl(manifestURL, { cache: 'no-cache' });
-    const responseText = await response.text();
-    const manifest = this.options.transformPluginManifest(JSON.parse(responseText));
+    const manifest = JSON.parse(await response.text());
 
     pluginManifestSchema.validateSync(manifest, { strict: true, abortEarly: false });
 
     return manifest;
+  }
+
+  transformPluginManifest(manifest: PluginManifest) {
+    return this.options.transformPluginManifest(manifest);
   }
 
   /**

--- a/packages/lib-core/src/runtime/PluginStore.ts
+++ b/packages/lib-core/src/runtime/PluginStore.ts
@@ -171,6 +171,8 @@ export class PluginStore implements PluginStoreInterface {
       throw new ErrorWithCause('Failed to load plugin manifest', e);
     }
 
+    loadedManifest = this.loader.transformPluginManifest(loadedManifest);
+
     const pluginName = loadedManifest.name;
 
     if (this.pendingPlugins.has(pluginName)) {

--- a/packages/lib-core/src/types/loader.ts
+++ b/packages/lib-core/src/types/loader.ts
@@ -16,9 +16,14 @@ export type PluginLoaderInterface = {
   /**
    * Load plugin manifest from the given URL.
    *
-   * This should include transforming and validating the manifest object as necessary.
+   * This should include validating the manifest object as necessary.
    */
   loadPluginManifest: (manifestURL: string) => Promise<PluginManifest>;
+
+  /**
+   * Transform the plugin manifest before loading the associated plugin.
+   */
+  transformPluginManifest: (manifest: PluginManifest) => PluginManifest;
 
   /**
    * Load plugin from the given manifest.

--- a/reports/lib-core.api.md
+++ b/reports/lib-core.api.md
@@ -149,6 +149,7 @@ export type PluginInfoEntry = PendingPluginInfoEntry | LoadedPluginInfoEntry | F
 // @public (undocumented)
 export type PluginLoaderInterface = {
     loadPluginManifest: (manifestURL: string) => Promise<PluginManifest>;
+    transformPluginManifest: (manifest: PluginManifest) => PluginManifest;
     loadPlugin: (manifest: PluginManifest) => Promise<PluginLoadResult>;
 };
 


### PR DESCRIPTION
This PR ensures that `transformPluginManifest` function is always called within `PluginStore.loadPlugin` in order to allow pre-processing of all manifest objects.