### PR TITLE
Remove loadError state if modify action is fired

### DIFF
--- a/packages/lib-utils/src/app/redux/reducers/k8s/k8s.ts
+++ b/packages/lib-utils/src/app/redux/reducers/k8s/k8s.ts
@@ -204,6 +204,15 @@ export const sdkK8sReducer = (state: K8sState, action: K8sAction): K8sState => {
       });
     }
 
+    case ActionType.ClearError: {
+      const { k8sObjects, id } = action.payload;
+      return state.mergeIn([id], {
+        loadError: '',
+        loaded: true,
+        data: k8sObjects,
+      });
+    }
+
     case ActionType.StopWatchK8s:
       return state.delete(action.payload.id);
 

--- a/reports/lib-utils.api.md
+++ b/reports/lib-utils.api.md
@@ -25,6 +25,8 @@ export enum ActionType {
     // (undocumented)
     BulkAddToList = "bulkAddToList",
     // (undocumented)
+    ClearError = "clearError",
+    // (undocumented)
     Errored = "errored",
     // (undocumented)
     FilterList = "filterList",
@@ -406,6 +408,12 @@ export const SDKReducers: Readonly<{
         };
     } | {
         type: import("../actions/k8s").ActionType.ModifyObject;
+        payload: {
+            id: string;
+            k8sObjects: K8sResourceCommon;
+        };
+    } | {
+        type: import("../actions/k8s").ActionType.ClearError;
         payload: {
             id: string;
             k8sObjects: K8sResourceCommon;


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHCLOUD-26143

Always update the state to clear loadError if an update action is fired but loadError is not empty in state.