### PR TITLE
Exclude non-user-facing chunk files from processing

### DIFF
--- a/packages/lib-webpack/src/utils/plugin-chunks.ts
+++ b/packages/lib-webpack/src/utils/plugin-chunks.ts
@@ -1,4 +1,4 @@
-import { Compilation, Chunk } from 'webpack';
+import { Compilation, Chunk, AssetInfo } from 'webpack';
 
 export const findPluginChunks = (
   containerName: string,
@@ -27,3 +27,18 @@ export const findPluginChunks = (
 
   return { entryChunk, runtimeChunk };
 };
+
+export const getChunkFiles = (
+  chunk: Chunk,
+  compilation: Compilation,
+  includeFile = (assetInfo: AssetInfo) => !assetInfo.development && !assetInfo.hotModuleReplacement,
+) =>
+  Array.from(chunk.files).filter((fileName) => {
+    const assetInfo = compilation.assetsInfo.get(fileName);
+
+    if (!assetInfo) {
+      throw new Error(`Missing asset information for ${fileName}`);
+    }
+
+    return includeFile(assetInfo);
+  });

--- a/packages/lib-webpack/src/webpack/GenerateManifestPlugin.ts
+++ b/packages/lib-webpack/src/webpack/GenerateManifestPlugin.ts
@@ -1,7 +1,7 @@
 import type { PluginManifest } from '@openshift/dynamic-plugin-sdk/src/shared-webpack';
 import type { WebpackPluginInstance, Compiler } from 'webpack';
 import { Compilation, sources, WebpackError } from 'webpack';
-import { findPluginChunks } from '../utils/plugin-chunks';
+import { findPluginChunks, getChunkFiles } from '../utils/plugin-chunks';
 
 type InputManifestData = Omit<PluginManifest, 'baseURL' | 'loadScripts' | 'buildHash'>;
 
@@ -38,7 +38,7 @@ export class GenerateManifestPlugin implements WebpackPluginInstance {
           const pluginChunks = runtimeChunk ? [runtimeChunk, entryChunk] : [entryChunk];
 
           const loadScripts = pluginChunks.reduce<string[]>(
-            (acc, chunk) => [...acc, ...chunk.files],
+            (acc, chunk) => [...acc, ...getChunkFiles(chunk, compilation)],
             [],
           );
 

--- a/packages/lib-webpack/src/webpack/PatchEntryCallbackPlugin.ts
+++ b/packages/lib-webpack/src/webpack/PatchEntryCallbackPlugin.ts
@@ -1,5 +1,5 @@
 import { WebpackPluginInstance, Compiler, Compilation, sources, WebpackError } from 'webpack';
-import { findPluginChunks } from '../utils/plugin-chunks';
+import { findPluginChunks, getChunkFiles } from '../utils/plugin-chunks';
 
 type PatchEntryCallbackPluginOptions = {
   containerName: string;
@@ -22,7 +22,7 @@ export class PatchEntryCallbackPlugin implements WebpackPluginInstance {
         () => {
           const { entryChunk } = findPluginChunks(containerName, compilation);
 
-          entryChunk.files.forEach((fileName) => {
+          getChunkFiles(entryChunk, compilation).forEach((fileName) => {
             compilation.updateAsset(fileName, (source) => {
               const newSource = new sources.ReplaceSource(source);
               const fromIndex = source.source().toString().indexOf(`${callbackName}(`);


### PR DESCRIPTION
[webpack-dev-server](https://github.com/webpack/webpack-dev-server) includes a [Hot Module Replacement](https://webpack.js.org/concepts/hot-module-replacement/) (HMR) feature controlled via [`devServer.hot`](https://webpack.js.org/configuration/dev-server/#devserverhot) configuration option.

When enabled, HMR causes [hot update chunks](https://webpack.js.org/configuration/output/#outputhotupdatechunkfilename) like `kubevirt-plugin.494371abc020603eb01f.hot-update.js` to be generated.

This PR modifies the following code:
- `GenerateManifestPlugin` - exclude non-user-facing chunk files from the `loadScripts` field in plugin manifest
- `PatchEntryCallbackPlugin` - exclude non-user-facing chunk files from JSONP entry callback post-processing

Note :memo: non-user-facing means `!assetInfo.development && !assetInfo.hotModuleReplacement`

This also fixes webpack compilation errors such as
```
ERROR in [entry] [initial] kubevirt-plugin.494371abc020603eb01f.hot-update.js
Missing call to loadPluginEntry
```