### PR TITLE
Expose plugin partials.

### DIFF
--- a/packages/lib-webpack/src/index.ts
+++ b/packages/lib-webpack/src/index.ts
@@ -30,5 +30,9 @@ export {
   PluginEntryCallbackSettings,
 } from './webpack/DynamicRemotePlugin';
 
+export * from './webpack/GenerateManifestPlugin';
+export * from './webpack/ValidateCompilationPlugin';
+
 export { PluginBuildMetadata } from './types/plugin';
 export { WebpackSharedConfig, WebpackSharedObject } from './types/webpack';
+export * from './yup-schemas';


### PR DESCRIPTION
### Why

Parts can be re-used to create new plugins for [@module/federation-enhanced](https://github.com/module-federation/universe/tree/main/packages/enhanced).