### PR TITLE
Allow overriding core webpack plugins used by DynamicRemotePlugin

### DIFF
--- a/packages/sample-app/src/app.tsx
+++ b/packages/sample-app/src/app.tsx
@@ -25,7 +25,7 @@ initSharedScope().then(() => {
   pluginStore.setFeatureFlags({ TELEMETRY_FLAG: true });
 
   // eslint-disable-next-line no-console
-  console.info(`Using plugin SDK version ${pluginStore.sdkVersion}`);
+  console.info(`Using plugin SDK runtime version ${pluginStore.sdkVersion}`);
 
   render(
     <PluginStoreProvider store={pluginStore}>

--- a/reports/lib-webpack.api.md
+++ b/reports/lib-webpack.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { Compiler } from 'webpack';
+import { container } from 'webpack';
 import { WebpackPluginInstance } from 'webpack';
 
 // @public
@@ -90,6 +91,10 @@ export type PluginManifest = PluginRuntimeMetadata & {
 export type PluginModuleFederationSettings = Partial<{
     libraryType: string;
     sharedScopeName: string;
+    pluginOverride: Partial<{
+        ModuleFederationPlugin: typeof container.ModuleFederationPlugin;
+        ContainerPlugin: typeof container.ContainerPlugin;
+    }>;
 }>;
 
 // @public (undocumented)


### PR DESCRIPTION
This PR adds new `moduleFederationSettings.pluginOverride` option to webpack `DynamicRemotePlugin`.

This allows us to use libraries like [`@module-federation/enhanced`](https://github.com/module-federation/universe/tree/main/packages/enhanced) for better interoperability with tools like [Rspack](https://www.rspack.dev/).

For example:

```ts
import { ModuleFederationPlugin, ContainerPlugin } from '@module-federation/enhanced';

// in your webpack plugins declaration
new DynamicRemotePlugin({
  pluginMetadata,
  extensions,
  moduleFederationSettings: {
    // use webpack plugins from @module-federation/enhanced package (as imported above)
    pluginOverride: { ModuleFederationPlugin, ContainerPlugin }
  }
})
```

Related to https://github.com/scalprum/scaffolding/pull/127 - cc @Hyperkid123 