### PR TITLE
fix(lib-webpack): use updated chunk API to generate plugin manifest

### DIFF
--- a/packages/lib-webpack/src/utils/plugin-chunks.ts
+++ b/packages/lib-webpack/src/utils/plugin-chunks.ts
@@ -19,7 +19,19 @@ export const findPluginChunks = (
     return { entryChunk };
   }
 
-  const runtimeChunk = allChunks.find((chunk) => chunk.name === entryChunk.runtime);
+  const runtimeChunk = allChunks.find((chunk) => {
+      /**
+       * In webpack chunk runtime can be one of undefined, string and a SortableSet.
+       * 
+       * If runtime is a SortableSet, a different check is needed.
+       */
+      if (typeof entryChunk.runtime === 'string') {
+        return chunk.name === entryChunk.runtime;
+      } else if (entryChunk.runtime) {
+        return entryChunk.runtime.has(chunk.name);
+      }
+    }
+  );
 
   if (!runtimeChunk) {
     throw new Error(`Cannot find runtime chunk for entry chunk ${containerName}`);
@@ -34,7 +46,7 @@ export const getChunkFiles = (
   includeFile = (assetInfo: AssetInfo) => !assetInfo.development && !assetInfo.hotModuleReplacement,
 ) =>
   Array.from(chunk.files).filter((fileName) => {
-    const assetInfo = compilation.assetsInfo.get(fileName);
+    const assetInfo = compilation.getAsset(fileName);
 
     if (!assetInfo) {
       throw new Error(`Missing asset information for ${fileName}`);


### PR DESCRIPTION
### Changes

Some adjustments are needed to ensure compatibility with RSPack. Thankfully, we can use standard Webpack API, only adjusting how we look at the compilation Chunks.

There are two changes
1. make sure we cover all possible Chunk types when checking the runtime
2. use the `getAsset(name: string)` rather than asset info to retrieve information about asset files