### PR TITLE
Publish lib-utils 5.0.0 (removes PF dependency)

### DIFF
--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-utils",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Provides React focused dynamic plugin SDK utilities",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Publishes https://github.com/openshift/dynamic-plugin-sdk/pull/247 to npm for consumption

```bash
npm notice 📦  @openshift/dynamic-plugin-sdk-utils@5.0.0
npm notice Tarball Contents
npm notice 96B README.md
npm notice 235B dist/build-metadata.json
npm notice 83.4kB dist/index.cjs.js
npm notice 29.2kB dist/index.d.ts
npm notice 78.4kB dist/index.esm.js
npm notice 1.4kB package.json
npm notice Tarball Details
npm notice name: @openshift/dynamic-plugin-sdk-utils
npm notice version: 5.0.0
npm notice filename: openshift-dynamic-plugin-sdk-utils-5.0.0.tgz
npm notice package size: 44.5 kB
npm notice unpacked size: 192.7 kB
npm notice shasum: fc39dc78849ee7d21eb429e3c2e8f4351d033b6d
npm notice integrity: sha512-FEfEp7R8hIs4c[...]ic681jVU+FEkA==
npm notice total files: 6
```