### PR TITLE
Publish lib-utils version 5.0.1

### DIFF
--- a/packages/lib-utils/package.json
+++ b/packages/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-utils",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Provides React focused dynamic plugin SDK utilities",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Publishes https://github.com/openshift/dynamic-plugin-sdk/pull/266 (dep updates to utils/extensions including redux 8 support)

```bash
npm notice
npm notice 📦  @openshift/dynamic-plugin-sdk-utils@5.0.1
npm notice Tarball Contents
npm notice 96B README.md
npm notice 255B dist/build-metadata.json
npm notice 83.5kB dist/index.cjs.js
npm notice 29.2kB dist/index.d.ts
npm notice 78.4kB dist/index.esm.js
npm notice 1.3kB package.json
npm notice Tarball Details
npm notice name: @openshift/dynamic-plugin-sdk-utils
npm notice version: 5.0.1
npm notice filename: openshift-dynamic-plugin-sdk-utils-5.0.1.tgz
npm notice package size: 44.6 kB
npm notice unpacked size: 192.7 kB
npm notice shasum: 45e8bebbb63929410d28b96ed746acbbdd93ca44
npm notice integrity: sha512-R6gDQy8pyBGbh[...]TXa0duSjoKBmw==
npm notice total files: 6
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access

+ @openshift/dynamic-plugin-sdk-utils@5.0.1
```