### PR TITLE
Publish lib-extensions 1.4.1

### DIFF
--- a/packages/lib-extensions/package.json
+++ b/packages/lib-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openshift/dynamic-plugin-sdk-extensions",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Provides extension types for dynamic plugins",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Publishes https://github.com/openshift/dynamic-plugin-sdk/pull/266 (dep updates to utils/extensions including redux 8 support) 

```bash
npm notice
npm notice 📦  @openshift/dynamic-plugin-sdk-extensions@1.4.1
npm notice Tarball Contents
npm notice 94B README.md
npm notice 265B dist/build-metadata.json
npm notice 3.5kB dist/index.cjs.js
npm notice 18.7kB dist/index.d.ts
npm notice 2.8kB dist/index.esm.js
npm notice 1.2kB package.json
npm notice Tarball Details
npm notice name: @openshift/dynamic-plugin-sdk-extensions
npm notice version: 1.4.1
npm notice filename: openshift-dynamic-plugin-sdk-extensions-1.4.1.tgz
npm notice package size: 5.9 kB
npm notice unpacked size: 26.6 kB
npm notice shasum: 8c99b972480d300600ae57219b0dac39ee15198c
npm notice integrity: sha512-py3bxKTMareMT[...]/Ee3MZU5tn0FA==
npm notice total files: 6
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access

+ @openshift/dynamic-plugin-sdk-extensions@1.4.1

```