### PR TITLE
CONSOLE-4621: Add support for optional dependencies

### DIFF
--- a/packages/lib-core/src/runtime/PluginLoader.ts
+++ b/packages/lib-core/src/runtime/PluginLoader.ts
@@ -351,7 +351,8 @@ export class PluginLoader implements PluginLoaderInterface {
   private resolvePluginDependencies(manifest: PluginManifest) {
     return new Promise<void>((resolve, reject) => {
       const pluginName = manifest.name;
-      const dependencies = manifest.dependencies ?? {};
+      const requiredDependencies = manifest.dependencies ?? {};
+      const optionalDependencies = manifest.optionalDependencies ?? {};
       const semverRangeOptions: semver.RangeOptions = { includePrerelease: true };
 
       let isResolutionComplete = false;
@@ -365,31 +366,33 @@ export class PluginLoader implements PluginLoaderInterface {
       const tryResolveDependencies = () => {
         const resolutions = this.getCurrentDependencyResolutions();
         const resolutionErrors: string[] = [];
+        const pendingDepNames: string[] = [];
 
-        Object.entries(dependencies).forEach(([depName, versionRange]) => {
-          if (resolutions.has(depName)) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const res = resolutions.get(depName)!;
+        Object.entries({ ...optionalDependencies, ...requiredDependencies }).forEach(
+          ([depName, versionRange]) => {
+            if (resolutions.has(depName)) {
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              const res = resolutions.get(depName)!;
+              const isRequired = !!requiredDependencies[depName];
 
-            if (res.success && !semver.satisfies(res.version, versionRange, semverRangeOptions)) {
-              resolutionErrors.push(
-                `Dependency ${depName} not met: required range ${versionRange}, resolved version ${res.version}`,
-              );
-            } else if (!res.success) {
-              resolutionErrors.push(`Dependency ${depName} could not be resolved successfully`);
+              if (res.success && !semver.satisfies(res.version, versionRange, semverRangeOptions)) {
+                resolutionErrors.push(
+                  `Dependency ${depName} not met: required range ${versionRange}, resolved version ${res.version}`,
+                );
+              } else if (!res.success && isRequired) {
+                resolutionErrors.push(`Dependency ${depName} could not be resolved successfully`);
+              }
+            } else {
+              pendingDepNames.push(depName);
             }
-          }
-        });
+          },
+        );
 
         if (resolutionErrors.length > 0) {
           setResolutionComplete();
           reject(new ErrorWithCause('Detected dependency resolution errors', resolutionErrors));
           return;
         }
-
-        const pendingDepNames = Object.keys(dependencies).filter(
-          (depName) => !resolutions.has(depName),
-        );
 
         if (pendingDepNames.length === 0) {
           setResolutionComplete();

--- a/packages/lib-core/src/types/plugin.ts
+++ b/packages/lib-core/src/types/plugin.ts
@@ -8,6 +8,7 @@ export type PluginRuntimeMetadata = {
   name: string;
   version: string;
   dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
   customProperties?: AnyObject;
 };
 

--- a/packages/lib-core/src/yup-schemas.ts
+++ b/packages/lib-core/src/yup-schemas.ts
@@ -101,6 +101,7 @@ export const pluginRuntimeMetadataSchema = yup.object().required().shape({
   // TODO(vojtech): Yup lacks native support for map-like structures with arbitrary keys
   // TODO(vojtech): we need to validate dependency values as semver ranges
   dependencies: yup.object(),
+  optionalDependencies: yup.object(),
   customProperties: yup.object(),
 });
 

--- a/reports/lib-core.api.md
+++ b/reports/lib-core.api.md
@@ -195,6 +195,7 @@ export type PluginRuntimeMetadata = {
     name: string;
     version: string;
     dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
     customProperties?: AnyObject;
 };
 

--- a/reports/lib-webpack.api.md
+++ b/reports/lib-webpack.api.md
@@ -105,6 +105,7 @@ export type PluginRuntimeMetadata = {
     name: string;
     version: string;
     dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
     customProperties?: AnyObject;
 };
 


### PR DESCRIPTION
This PR adapts openshift/console#15183 changes to support optional dependencies.

## Summary

Dynamic plugins may depend on
- other dynamic plugins - **regular dependencies**
- environment specific constants - **environment dependencies** (*)

(*) Provided by host application via `PluginLoader` option `fixedPluginDependencyResolutions`

Every dependency (regular or environment related) may be declared as
- **required** - using `dependencies` object in build metadata
- **optional** - using `optionalDependencies` object in build metadata

### Resolution logic

Failure to resolve all of the plugin's required dependencies will cause that plugin to load with failed status.

Failure to resolve any of the plugin's optional dependencies will not prevent that plugin from loading, i.e. await optional dependency resolution but don't fail if the resolution was not a success.

:memo: If the optional dependency resolution was a success but the resolved version does not match the plugin's expectation, that plugin will fail to load with the following error message:
```
`Dependency ${depName} not met: required range ${versionRange}, resolved version ${res.version}`
```

## Test cases

### Plugin A has optional dependency on plugin B
- plugin B loads with error :arrow_forward: plugin A loads OK :white_check_mark:
- plugin B loads successfully and its version matches the expected range :arrow_forward: plugin A loads OK :white_check_mark:
- plugin B loads successfully and its version does not match the expected range :arrow_forward: plugin A fails to load :x:

### Plugin A has optional dependency on environment constant C
- version of constant C matches the expected range :arrow_forward: plugin A loads OK :white_check_mark:
- version of constant C does not match the expected range :arrow_forward: plugin A fails to load :x:
