### PR TITLE
fix CodeRef map types to be precise and support optional code refs

### DIFF
--- a/packages/lib-core/src/index.ts
+++ b/packages/lib-core/src/index.ts
@@ -54,6 +54,8 @@ export {
   EncodedExtension,
   LoadedExtension,
   ResolvedExtension,
+  CodeRefsToValues,
+  CodeRefsToEncodedCodeRefs,
   MapCodeRefsToEncodedCodeRefs,
   MapCodeRefsToValues,
   ExtractExtensionProperties,

--- a/packages/lib-core/src/types/extension.ts
+++ b/packages/lib-core/src/types/extension.ts
@@ -23,14 +23,28 @@ export type EncodedCodeRef = { $codeRef: string };
 
 export type CodeRef<TValue = unknown> = () => Promise<TValue>;
 
-// TODO(vojtech): apply the recursive part only on object properties or array elements
-export type MapCodeRefsToValues<T> = {
-  [K in keyof T]: T[K] extends CodeRef<infer TValue> ? TValue : MapCodeRefsToValues<T[K]>;
+export type CodeRefsToValues<T> = T extends CodeRef<infer TValue>
+  ? TValue
+  : T extends (infer U)[]
+  ? CodeRefsToValues<U>[]
+  : T extends object
+  ? MapCodeRefsToValues<T>
+  : T;
+
+export type MapCodeRefsToValues<T extends object> = {
+  [K in keyof T]: CodeRefsToValues<T[K]>;
 };
 
-// TODO(vojtech): apply the recursive part only on object properties or array elements
-export type MapCodeRefsToEncodedCodeRefs<T> = {
-  [K in keyof T]: T[K] extends CodeRef ? EncodedCodeRef : MapCodeRefsToEncodedCodeRefs<T[K]>;
+export type CodeRefsToEncodedCodeRefs<T> = T extends CodeRef
+  ? EncodedCodeRef
+  : T extends (infer U)[]
+  ? CodeRefsToEncodedCodeRefs<U>[]
+  : T extends object
+  ? MapCodeRefsToEncodedCodeRefs<T>
+  : T;
+
+export type MapCodeRefsToEncodedCodeRefs<T extends object> = {
+  [K in keyof T]: CodeRefsToEncodedCodeRefs<T[K]>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/lib-webpack/src/index.ts
+++ b/packages/lib-webpack/src/index.ts
@@ -16,6 +16,7 @@ export {
   Extension,
   ExtensionFlags,
   EncodedExtension,
+  CodeRefsToEncodedCodeRefs,
   MapCodeRefsToEncodedCodeRefs,
   ExtractExtensionProperties,
   PluginRegistrationMethod,

--- a/reports/lib-core.api.md
+++ b/reports/lib-core.api.md
@@ -18,6 +18,12 @@ export const applyOverrides: <TObject>(obj: TObject, overrides: unknown) => TObj
 // @public (undocumented)
 export type CodeRef<TValue = unknown> = () => Promise<TValue>;
 
+// @public (undocumented)
+export type CodeRefsToEncodedCodeRefs<T> = T extends CodeRef ? EncodedCodeRef : T extends (infer U)[] ? CodeRefsToEncodedCodeRefs<U>[] : T extends object ? MapCodeRefsToEncodedCodeRefs<T> : T;
+
+// @public (undocumented)
+export type CodeRefsToValues<T> = T extends CodeRef<infer TValue> ? TValue : T extends (infer U)[] ? CodeRefsToValues<U>[] : T extends object ? MapCodeRefsToValues<T> : T;
+
 // @public
 export const consoleLogger: Logger;
 
@@ -106,13 +112,13 @@ export type LogFunction = (message?: any, ...optionalParams: any[]) => void;
 export type Logger = Record<'info' | 'warn' | 'error', LogFunction>;
 
 // @public (undocumented)
-export type MapCodeRefsToEncodedCodeRefs<T> = {
-    [K in keyof T]: T[K] extends CodeRef ? EncodedCodeRef : MapCodeRefsToEncodedCodeRefs<T[K]>;
+export type MapCodeRefsToEncodedCodeRefs<T extends object> = {
+    [K in keyof T]: CodeRefsToEncodedCodeRefs<T[K]>;
 };
 
 // @public (undocumented)
-export type MapCodeRefsToValues<T> = {
-    [K in keyof T]: T[K] extends CodeRef<infer TValue> ? TValue : MapCodeRefsToValues<T[K]>;
+export type MapCodeRefsToValues<T extends object> = {
+    [K in keyof T]: CodeRefsToValues<T[K]>;
 };
 
 // @public

--- a/reports/lib-webpack.api.md
+++ b/reports/lib-webpack.api.md
@@ -15,6 +15,9 @@ export type AnyObject = Record<string, unknown>;
 export type CodeRef<TValue = unknown> = () => Promise<TValue>;
 
 // @public (undocumented)
+export type CodeRefsToEncodedCodeRefs<T> = T extends CodeRef ? EncodedCodeRef : T extends (infer U)[] ? CodeRefsToEncodedCodeRefs<U>[] : T extends object ? MapCodeRefsToEncodedCodeRefs<T> : T;
+
+// @public (undocumented)
 export class DynamicRemotePlugin implements WebpackPluginInstance {
     constructor(options: DynamicRemotePluginOptions);
     // (undocumented)
@@ -61,8 +64,8 @@ export type ExtensionFlags = Partial<{
 export type ExtractExtensionProperties<T> = T extends Extension<any, infer TProperties> ? TProperties : never;
 
 // @public (undocumented)
-export type MapCodeRefsToEncodedCodeRefs<T> = {
-    [K in keyof T]: T[K] extends CodeRef ? EncodedCodeRef : MapCodeRefsToEncodedCodeRefs<T[K]>;
+export type MapCodeRefsToEncodedCodeRefs<T extends object> = {
+    [K in keyof T]: CodeRefsToEncodedCodeRefs<T[K]>;
 };
 
 // @public (undocumented)


### PR DESCRIPTION
Using optional chaining for conditional `CodeRef` give typescript error. 
Types `MapCodeRefsToValues` and `MapCodeRefsToEncodedCodeRefs` have a `TODO` in order to apply recursive mapping while at the same time not supporting optional `CodeRef` properties.

Since there are no optional `CodeRef` properties in the repo to test with. I changed the `core.telemetry/listener` extension to have an optional listener to show the error:
```
export declare type TelemetryListener = Extension<
  'core.telemetry/listener',
  {
    /** Listen for telemetry events */
    listener?: CodeRef<TelemetryEventListener>;
  }
>;
```

Before:
<img width="839" height="240" alt="image" src="https://github.com/user-attachments/assets/5e901d50-906e-4d32-aa4a-f1c329e9895d" />

After:
<img width="562" height="120" alt="image" src="https://github.com/user-attachments/assets/44b1d1d8-94f1-42f8-a1ad-7474c3887028" />
