### PR TITLE
Add PluginStore.copyFrom method

### DIFF
--- a/packages/lib-core/CHANGELOG.md
+++ b/packages/lib-core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 9.0.0 - TBD
 
 - BREAKING: Modify `useResolvedExtensions` hook to accept `extensions` array as a parameter ([#313])
+- Add `PluginStore.copyFrom` method ([#324])
 - Expose `visitDeep` utility function ([#313])
 
 ## 8.2.0 - 2026-03-19
@@ -144,3 +145,4 @@
 [#309]: https://github.com/openshift/dynamic-plugin-sdk/pull/309
 [#310]: https://github.com/openshift/dynamic-plugin-sdk/pull/310
 [#313]: https://github.com/openshift/dynamic-plugin-sdk/pull/313
+[#324]: https://github.com/openshift/dynamic-plugin-sdk/pull/324

--- a/packages/lib-core/src/runtime/PluginStore.ts
+++ b/packages/lib-core/src/runtime/PluginStore.ts
@@ -375,4 +375,35 @@ export class PluginStore implements PluginStoreInterface {
 
     return referencedModule;
   }
+
+  /**
+   * Create new `PluginStore` with state copied from the source `PluginStore`.
+   *
+   * @remarks
+   *
+   * Does not copy subscribed event {@link listeners} and {@link pendingPromises}.
+   */
+  static copyFrom(source: PluginStore): PluginStore {
+    const target = new PluginStore({
+      autoEnableLoadedPlugins: source.options.autoEnableLoadedPlugins,
+      loader: source.loader,
+    });
+
+    source.pendingPlugins.forEach((plugin, name) => {
+      target.pendingPlugins.set(name, { ...plugin });
+    });
+
+    source.loadedPlugins.forEach((plugin, name) => {
+      target.loadedPlugins.set(name, { ...plugin });
+    });
+
+    source.failedPlugins.forEach((plugin, name) => {
+      target.failedPlugins.set(name, { ...plugin });
+    });
+
+    target.extensions = [...source.extensions];
+    target.featureFlags = { ...source.featureFlags };
+
+    return target;
+  }
 }

--- a/reports/lib-core.api.md
+++ b/reports/lib-core.api.md
@@ -254,6 +254,7 @@ export class PluginStore implements PluginStoreInterface {
     protected addLoadedPlugin(manifest: PluginManifest, loadedExtensions: LoadedExtension[], entryModule?: PluginEntryModule): void;
     // (undocumented)
     protected addPendingPlugin(manifest: PluginManifest): void;
+    static copyFrom(source: PluginStore): PluginStore;
     // (undocumented)
     disablePlugins(pluginNames: string[], disableReason?: string): void;
     // (undocumented)


### PR DESCRIPTION
This method can be used in unit tests to copy internal state of an existing `PluginStore` into a new `PluginStore` instance.

```ts
const testPluginStore = PluginStore.copyFrom(appStoreImpl);
```