### PR TITLE
Skip redundant CRD collection and build steps

### DIFF
--- a/packages/lib-api-types/collect-crds.sh
+++ b/packages/lib-api-types/collect-crds.sh
@@ -11,13 +11,14 @@ EXTRACT_DIR="$CACHE_DIR/openshift-api"
 mkdir -p "$CACHE_DIR"
 
 if [ ! -d "$EXTRACT_DIR" ]; then
-  curl --fail --silent --location -o "$ARCHIVE" "$OPENSHIFT_API_URL"
+  curl --fail --location -o "$ARCHIVE" "$OPENSHIFT_API_URL"
   mkdir -p "$EXTRACT_DIR"
   tar -xzf "$ARCHIVE" -C "$EXTRACT_DIR" --strip-components=1
   rm "$ARCHIVE"
 fi
 
-mkdir -p "$CACHE_DIR/openshift-crds"
-rm -rf "$CACHE_DIR/openshift-crds"/*
-cd "$CACHE_DIR/openshift-crds"
-find ../openshift-api -type f -name "*.crd.yaml" -exec ln -sf {} ./ \;
+if [ ! -d "$CACHE_DIR/openshift-crds" ]; then
+  mkdir -p "$CACHE_DIR/openshift-crds"
+  cd "$CACHE_DIR/openshift-crds"
+  find ../openshift-api -type f -name "*.crd.yaml" -exec ln -sf {} ./ \;
+fi

--- a/packages/lib-api-types/package.json
+++ b/packages/lib-api-types/package.json
@@ -22,7 +22,8 @@
     "generate-types-prep": "mkdir -p dist && cp src/k8s-common.ts dist/k8s-common.d.ts",
     "generate-types": "yarn generate-types-prep && yarn run -T ts-node src/generate-types.ts",
     "generate-metadata": "yarn run -T ts-node src/build-metadata.ts",
-    "build": "yarn clean-dist && yarn generate-collect && yarn generate-types-prep && yarn generate-types && yarn generate-format && yarn generate-metadata && yarn update-types",
+    "build-for-real": "yarn clean-dist && yarn generate-collect && yarn generate-types-prep && yarn generate-types && yarn generate-format && yarn generate-metadata && yarn update-types",
+    "build": "[ -d dist ] && echo 'dist directory found, rebuild skipped' || yarn build-for-real",
     "test": "yarn run -T test $INIT_CWD",
     "update-sources": "jq -r 'keys[]' sources.json | while read repo; do sha=$(gh api repos/$repo/commits/HEAD --jq .sha); echo \"$repo: $sha\"; jq --arg r \"$repo\" --arg s \"$sha\" '.[$r]=$s' sources.json > sources.tmp && mv sources.tmp sources.json; done",
     "update-types": "cp dist/kubernetes/**/CustomResourceDefinition.d.ts src/k8s/v1/CRD/CustomResourceDefinition.d.ts"


### PR DESCRIPTION
Optimize build performance by caching CRD collection and type generation. The collect-crds.sh script now skips linking CRDs if the cache directory already exists, and the build script skips the full build if dist is already present. This reduces rebuild time significantly when running build commands multiple times.