### PR TITLE
Fix WebSocketFactory auto-reconnect never scheduling

### DIFF
--- a/packages/lib-utils/src/web-socket/WebSocketFactory.ts
+++ b/packages/lib-utils/src/web-socket/WebSocketFactory.ts
@@ -41,7 +41,7 @@ export class WebSocketFactory {
 
   private messageBuffer: MessageDataType[] = [];
 
-  private connectionAttempt = -1;
+  private connectionAttempt = 0;
 
   private ws: WebSocket | null = null;
 
@@ -80,12 +80,12 @@ export class WebSocketFactory {
     const attempt = async () => {
       if (!this.options.reconnect || this.state === WebSocketState.OPENED) {
         window.clearTimeout(this.connectionAttempt);
-        this.connectionAttempt = -1;
+        this.connectionAttempt = 0;
         return;
       }
       if (this.options.timeout && duration > this.options.timeout) {
         window.clearTimeout(this.connectionAttempt);
-        this.connectionAttempt = -1;
+        this.connectionAttempt = 0;
         this.destroy();
         return;
       }
@@ -121,7 +121,7 @@ export class WebSocketFactory {
       this.triggerEvent('open', undefined);
       if (this.connectionAttempt) {
         window.clearTimeout(this.connectionAttempt);
-        this.connectionAttempt = -1;
+        this.connectionAttempt = 0;
       }
     };
     this.ws.onclose = (evt) => {


### PR DESCRIPTION
- Change `connectionAttempt` from `-1` to `0` so `reconnect()` isn’t short-circuited by a truthy value.

Fixes [#323](https://github.com/openshift/dynamic-plugin-sdk/issues/323)
